### PR TITLE
Make the sdkVersion in RestRequest publicly settable

### DIFF
--- a/IBMWatsonRestKit.podspec
+++ b/IBMWatsonRestKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonRestKit'
-  s.version               = '1.0.0'
+  s.version               = '1.1.0'
   s.summary               = 'Networking layer for the IBM Watson Swift SDK'
   s.license               = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.homepage              = 'https://www.ibm.com/watson/'

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -22,7 +22,6 @@ public struct RestRequest {
 
     public static let userAgent: String = {
         let sdk = "watson-apis-swift-sdk"
-        let sdkVersion = "0.32.0"
 
         let operatingSystem: String = {
             #if os(iOS)
@@ -46,6 +45,10 @@ public struct RestRequest {
         }()
         return "\(sdk)/\(sdkVersion) \(operatingSystem)/\(operatingSystemVersion)"
     }()
+
+    /// The version of the IBM Watson Swift SDK that is being used
+    /// Must be assigned a value prior to making any requests to appear in the User-Agent header
+    public static var sdkVersion: String = "0.33.0"
 
     private let session: URLSession
     internal var authMethod: AuthenticationMethod


### PR DESCRIPTION
Required due to the decoupling of RestKit from the Watson Swift SDK. 

Since the RestKit is its own product now, the version of RestKit is independent of the version of the Watson SDK service that uses it. This means that we need to set `sdkVersion` (used in the "User-Agent" header for each request) on the service side. I gave it a default version of `0.33.0` since this is a bug that currently only exists in that version. It's ugly, but will fix the issue.

With this approach, we would then need to update the initializer for every Swift SDK service to call a common initializer that sets the value of `RestKit.sdkVersion`. That way the version is set before any requests are made.