### PR TITLE
Make the userAgent property in RestRequest publicly settable

### DIFF
--- a/IBMWatsonRestKit.podspec
+++ b/IBMWatsonRestKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonRestKit'
-  s.version               = '1.0.0'
+  s.version               = '1.1.0'
   s.summary               = 'Networking layer for the IBM Watson Swift SDK'
   s.license               = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.homepage              = 'https://www.ibm.com/watson/'

--- a/IBMWatsonRestKit.podspec
+++ b/IBMWatsonRestKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonRestKit'
-  s.version               = '1.1.0'
+  s.version               = '1.2.0'
   s.summary               = 'Networking layer for the IBM Watson Swift SDK'
   s.license               = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.homepage              = 'https://www.ibm.com/watson/'

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -22,7 +22,6 @@ public struct RestRequest {
 
     public static let userAgent: String = {
         let sdk = "watson-apis-swift-sdk"
-        let sdkVersion = "0.32.0"
 
         let operatingSystem: String = {
             #if os(iOS)
@@ -46,6 +45,10 @@ public struct RestRequest {
         }()
         return "\(sdk)/\(sdkVersion) \(operatingSystem)/\(operatingSystemVersion)"
     }()
+
+    /// The version of the IBM Watson Swift SDK that is being used
+    /// Must be assigned a value prior to making any requests to appear in the User-Agent header
+    public static var sdkVersion: String = "0.33.0"
 
     private let session: URLSession
     internal var authMethod: AuthenticationMethod

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -20,7 +20,11 @@ import Foundation
 
 public struct RestRequest {
 
-    public static let userAgent: String = {
+    // TODO: For RestKit version 2.0, remove the setter. This should only be set by the Watson Swift SDK.
+    // This needs to stay until 2.0 because Carthage will cause it to break with Watson Swift SDK v0.33.
+    /// The "User-Agent" header that will be sent with every network request
+    /// This can include information such as the operating system and the SDK/framework calling this API
+    public static var userAgent: String = {
         let sdk = "watson-apis-swift-sdk"
 
         let operatingSystem: String = {
@@ -46,8 +50,7 @@ public struct RestRequest {
         return "\(sdk)/\(sdkVersion) \(operatingSystem)/\(operatingSystemVersion)"
     }()
 
-    /// The version of the IBM Watson Swift SDK that is being used
-    /// Must be assigned a value prior to making any requests to appear in the User-Agent header
+    // TODO: Remove this in RestKit version 2.0
     public static var sdkVersion: String = "0.33.0"
 
     private let session: URLSession


### PR DESCRIPTION
This is a better implementation of https://github.com/watson-developer-cloud/restkit/pull/2.