### PR TITLE
Improve error handling for multipart data methods

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		92048D8C212F5BEE004FD822 /* RestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D85212F5BEE004FD822 /* RestError.swift */; };
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
-		CA542769215558740035F8B6 /* RestKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* RestKitTests.swift */; };
+		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
 /* End PBXBuildFile section */
 
@@ -49,7 +49,7 @@
 		92048D85212F5BEE004FD822 /* RestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RestError.swift; path = RestKit/RestError.swift; sourceTree = "<group>"; };
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
-		CA542768215558740035F8B6 /* RestKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestKitTests.swift; path = RestKitTests/RestKitTests.swift; sourceTree = "<group>"; };
+		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -111,7 +111,7 @@
 				92048D7C212F5BA2004FD822 /* AuthenticationTests.swift */,
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
-				CA542768215558740035F8B6 /* RestKitTests.swift */,
+				CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */,
 				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
 			);
@@ -270,7 +270,7 @@
 			files = (
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
-				CA542769215558740035F8B6 /* RestKitTests.swift in Sources */,
+				CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		92048D8C212F5BEE004FD822 /* RestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D85212F5BEE004FD822 /* RestError.swift */; };
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
+		CA542769215558740035F8B6 /* RestKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* RestKitTests.swift */; };
+		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +49,8 @@
 		92048D85212F5BEE004FD822 /* RestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RestError.swift; path = RestKit/RestError.swift; sourceTree = "<group>"; };
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
+		CA542768215558740035F8B6 /* RestKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestKitTests.swift; path = RestKitTests/RestKitTests.swift; sourceTree = "<group>"; };
+		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +111,8 @@
 				92048D7C212F5BA2004FD822 /* AuthenticationTests.swift */,
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
+				CA542768215558740035F8B6 /* RestKitTests.swift */,
+				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
 			);
 			path = Tests;
@@ -127,6 +133,14 @@
 				92048D56212F49C8004FD822 /* Info.plist */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		CA54276A215573F60035F8B6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				CA54276B215574380035F8B6 /* TestData.txt */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -229,6 +243,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA54276D2155763E0035F8B6 /* TestData.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,6 +270,7 @@
 			files = (
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
+				CA542769215558740035F8B6 /* RestKitTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -21,8 +21,8 @@ public class MultipartFormData {
     public var contentType: String { return "multipart/form-data; boundary=\(boundary)" }
     // add contentLength?
 
-    private let boundary: String
-    private var bodyParts = [BodyPart]()
+    let boundary: String
+    var bodyParts = [BodyPart]()
 
     // Strings in Swift use Unicode internally, so encoding a string using a Unicode encoding will always succeed.
     // swiftlint:disable force_unwrapping
@@ -58,6 +58,15 @@ public class MultipartFormData {
         }
     }
 
+    public func append(file fileURL: URL, withName: String, mimeType: String? = nil) throws {
+       if let data = try? Data.init(contentsOf: fileURL) {
+            let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
+            bodyParts.append(bodyPart)
+        } else {
+            throw RestError.serializationError
+        }
+    }
+
     public func toData() throws -> Data {
         var data = Data()
         for (index, bodyPart) in bodyParts.enumerated() {
@@ -80,7 +89,7 @@ public class MultipartFormData {
     }
 }
 
-private struct BodyPart {
+internal struct BodyPart {
 
     private(set) var key: String
     private(set) var data: Data

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -52,14 +52,14 @@ public class MultipartFormData {
     }
 
     public func append(_ fileURL: URL, withName: String, mimeType: String? = nil) {
-        if let data = try? Data.init(contentsOf: fileURL) {
+        if let data = try? Data(contentsOf: fileURL) {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         }
     }
 
     public func append(file fileURL: URL, withName: String, mimeType: String? = nil) throws {
-       if let data = try? Data.init(contentsOf: fileURL) {
+       if let data = try? Data(contentsOf: fileURL) {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {

--- a/Tests/Resources/TestData.txt
+++ b/Tests/Resources/TestData.txt
@@ -1,0 +1,1 @@
+Test Data stored in a file.

--- a/Tests/RestKitTests/MultiPartFormDataTests.swift
+++ b/Tests/RestKitTests/MultiPartFormDataTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import RestKit
 
-class RestKitTests: XCTestCase {
+class MultiPartFormDataTests: XCTestCase {
 
     static var allTests = [
         ("testSimpleFormData", testSimpleFormData),

--- a/Tests/RestKitTests/RestKitTests.swift
+++ b/Tests/RestKitTests/RestKitTests.swift
@@ -1,0 +1,91 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
+
+import XCTest
+@testable import RestKit
+
+class RestKitTests: XCTestCase {
+
+    static var allTests = [
+        ("testSimpleFormData", testSimpleFormData),
+        ("testFormData", testFormData),
+        ("testFormDataFromURL", testFormDataFromURL),
+        ("testFormDataWithInvalidURL", testFormDataWithInvalidURL)
+    ]
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func loadResource(name: String, ext: String) -> URL {
+        #if os(Linux)
+        return URL(fileURLWithPath: "Tests/RestKitTests/Resources/" + name + "." + ext)
+        #else
+        let bundle = Bundle(for: type(of: self))
+        guard let url = bundle.url(forResource: name, withExtension: ext) else {
+            XCTFail("Unable to locate resource.")
+            assert(false)
+        }
+        return url
+        #endif
+    }
+
+    // MARK: - MultipartFormData tests
+
+    func testSimpleFormData() {
+        let field1Data = "This is test data for field1".data(using: .utf8)!
+        let multipartFormData = MultipartFormData()
+        multipartFormData.append(field1Data, withName: "field1")
+        XCTAssertEqual(1, multipartFormData.bodyParts.count)
+        XCTAssertEqual("field1", multipartFormData.bodyParts[0].key)
+    }
+
+    func testFormData() {
+        let htmlData = "<html><body><h1>This is test html data</h1></body></html>".data(using: .utf8)!
+        let multipartFormData = MultipartFormData()
+        multipartFormData.append(htmlData, withName: "html", mimeType: "text/html", fileName: "test.html")
+        XCTAssertEqual(1, multipartFormData.bodyParts.count)
+        XCTAssertEqual("html", multipartFormData.bodyParts[0].key)
+        XCTAssertEqual("text/html", multipartFormData.bodyParts[0].mimeType)
+        XCTAssertEqual("test.html", multipartFormData.bodyParts[0].fileName)
+    }
+
+    func testFormDataFromURL() {
+        let testDataFile = loadResource(name: "TestData", ext: "txt")
+        let multipartFormData = MultipartFormData()
+        multipartFormData.append(testDataFile, withName: "test_data", mimeType: "application/octet-stream")
+        XCTAssertEqual(1, multipartFormData.bodyParts.count)
+        XCTAssertEqual("test_data", multipartFormData.bodyParts[0].key)
+        XCTAssertEqual("application/octet-stream", multipartFormData.bodyParts[0].mimeType)
+        XCTAssertEqual("TestData.txt", multipartFormData.bodyParts[0].fileName)
+    }
+
+    func testFormDataWithInvalidURL() {
+        let testDataFile = URL(string: "https://x.y.z/this/isnt/valid")!
+        let multipartFormData = MultipartFormData()
+        // append with invalid fileURL should throw
+        XCTAssertThrowsError(try multipartFormData.append(file: testDataFile, withName: "test_data", mimeType: "application/octet-stream"))
+    }
+
+}


### PR DESCRIPTION
This PR adds a new method that reports an error to the caller, via an exception, if the file -> data conversion fails when appending a file to a multipart/form-data request body.

I've also added some tests to verify the behavior of this new method and some of the base multipart formdata methods.