### PR TITLE
Error handling

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		92048D8C212F5BEE004FD822 /* RestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D85212F5BEE004FD822 /* RestError.swift */; };
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
+		92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547735216BEFC8003C2829 /* RestErrorTests.swift */; };
 		92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */; };
 		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
@@ -50,6 +51,7 @@
 		92048D85212F5BEE004FD822 /* RestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RestError.swift; path = RestKit/RestError.swift; sourceTree = "<group>"; };
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
+		92547735216BEFC8003C2829 /* RestErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestErrorTests.swift; path = RestKitTests/RestErrorTests.swift; sourceTree = "<group>"; };
 		92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WatsonResponse.swift; path = RestKit/WatsonResponse.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
 				CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */,
+				92547735216BEFC8003C2829 /* RestErrorTests.swift */,
 				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
 			);
@@ -274,6 +277,7 @@
 			files = (
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
+				92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */,
 				CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -87,7 +87,7 @@ public class BasicAuthentication: AuthenticationMethod {
                 request.addValue(token, forHTTPHeaderField: "X-Watson-Authorization-Token")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }
@@ -106,7 +106,7 @@ public class BasicAuthentication: AuthenticationMethod {
     private func requestToken(completionHandler: @escaping (String?, Error?) -> Void) {
 
         guard let tokenURL = tokenURL else {
-            completionHandler(nil, RestError.failure(400, "Websocket authentication requires tokenURL"))
+            completionHandler(nil, RestError.http(statusCode: 400, message: "Websocket authentication requires tokenURL"))
             return
         }
 
@@ -152,7 +152,7 @@ public class BasicAuthentication: AuthenticationMethod {
             }
         } catch { /* no need to catch -- falls back to default description */ }
 
-        return RestError.failure(code, message)
+        return RestError.http(statusCode: code, message: message)
     }
 }
 
@@ -231,7 +231,7 @@ public class IAMAuthentication: AuthenticationMethod {
 
     internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.failure(response.statusCode, genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }
 
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
@@ -241,7 +241,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.headerParameters["Authorization"] = "Bearer \(token.accessToken)"
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }
@@ -253,7 +253,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serialization)
+            completionHandler(nil, RestError.serialization("username and password"))
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -298,7 +298,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, RestError?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serialization); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization("IAM token")); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serialization("username and password"))
+            completionHandler(nil, RestError.serialization(values: "username and password", metadata: nil))
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -298,7 +298,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, RestError?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serialization("IAM token")); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization(values: "IAM token", metadata: nil)); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization)
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -297,7 +297,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, Error?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serializationError); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -73,10 +73,8 @@ public class MultipartFormData {
             let bodyBoundary: Data
             if index == 0 {
                 bodyBoundary = initialBoundary
-            } else if index != 0 {
-                bodyBoundary = encapsulatedBoundary
             } else {
-                throw RestError.encoding
+                bodyBoundary = encapsulatedBoundary
             }
 
             data.append(bodyBoundary)
@@ -129,7 +127,7 @@ internal struct BodyPart {
         var result = Data()
         let headerString = header
         guard let header = headerString.data(using: .utf8) else {
-            throw RestError.encoding
+            throw RestError.serialization(values: headerString, metadata: nil)
         }
         result.append(header)
         result.append(data)

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serialization
+            throw RestError.serialization("file contents")
         }
     }
 

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serializationError
+            throw RestError.serialization
         }
     }
 
@@ -76,7 +76,7 @@ public class MultipartFormData {
             } else if index != 0 {
                 bodyBoundary = encapsulatedBoundary
             } else {
-                throw RestError.encodingError
+                throw RestError.encoding
             }
 
             data.append(bodyBoundary)
@@ -129,7 +129,7 @@ internal struct BodyPart {
         var result = Data()
         let headerString = header
         guard let header = headerString.data(using: .utf8) else {
-            throw RestError.encodingError
+            throw RestError.encoding
         }
         result.append(header)
         result.append(data)

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serialization("file contents")
+            throw RestError.serialization(values: "file contents", metadata: nil)
         }
     }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -43,7 +43,7 @@ public enum RestError {
     case badURL
 
     /// An HTTP error with a status code and description.
-    case failure(Int, String)
+    case http(statusCode: Int, message: String)
 
 }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// An error from processing a network request or response.
-public enum RestError: Error {
+public enum RestError {
 
     /// No response was received from the server.
     case noResponse
@@ -45,4 +45,40 @@ public enum RestError: Error {
     /// An HTTP error with a status code and description.
     case failure(Int, String)
 
+}
+
+
+extension RestError: LocalizedError {
+
+    /// The status code returned by the server
+    public var statusCode: Int? {
+        switch self {
+        case .http(statusCode: let statusCode, _):
+            return statusCode
+        default:
+            return nil
+        }
+    }
+
+    /// A localized message describing what error occurred
+    public var errorDescription: String? {
+        switch self {
+        case .noResponse:
+            return "No response was received from the server"
+        case .noData:
+            return "No data was returned by the server"
+        case .serializationError:
+            return "Failed to serialize the data"
+        case .encodingError:
+            return "Failed to replace special characters in the URL path with percent encoded characters"
+        case .fileManagerError:
+            return "Failed the handle the provided file"
+        case .invalidFile:
+            return "Cannot load the provided file"
+        case .badURL:
+            return "Malformed URL"
+        case .http(_, message: let message):
+            return message
+        }
+    }
 }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -30,7 +30,7 @@ public enum RestError {
     case saveData
 
     /// Failed to serialize value(s) to data.
-    case serialization
+    case serialization(String)
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
@@ -66,8 +66,8 @@ extension RestError: LocalizedError {
             return "No data was returned by the server"
         case .saveData:
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
-        case .serialization:
-            return "Failed to serialize the data"
+        case .serialization(let values):
+            return "Failed to serialize " + values
         case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
         case .badURL:

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -40,7 +40,7 @@ public enum RestError {
     case badURL
 
     /// Generic HTTP error with a status code and description.
-    case http(statusCode: Int, message: String)
+    case http(statusCode: Int?, message: String?)
 
 }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -34,7 +34,7 @@ public enum RestError {
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
-    case encoding
+    case encoding(path: String)
 
     /// The request failed because the URL was malformed.
     case badURL
@@ -68,8 +68,8 @@ extension RestError: LocalizedError {
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
         case .serialization(let values, _):
             return "Failed to serialize " + values
-        case .encoding:
-            return "Failed to replace special characters in the URL path with percent encoded characters"
+        case .encoding(let path):
+            return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"
         case .http(_, message: let message):

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -30,7 +30,7 @@ public enum RestError {
     case saveData
 
     /// Failed to serialize value(s) to data.
-    case serialization(String)
+    case serialization(values: String, metadata: [String: JSON]?)
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
@@ -66,7 +66,7 @@ extension RestError: LocalizedError {
             return "No data was returned by the server"
         case .saveData:
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
-        case .serialization(let values):
+        case .serialization(let values, _):
             return "Failed to serialize " + values
         case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
@@ -74,6 +74,26 @@ extension RestError: LocalizedError {
             return "Malformed URL"
         case .http(_, message: let message):
             return message
+        }
+    }
+
+    /// Contains additional information associated with the error
+    /// Currently only supported for `RestError.serialization` and `RestError.http`
+    public var metadata: [String: JSON]? {
+        switch self {
+        case .serialization(_, let metadata):
+            return metadata
+        case .http(let statusCode, let message):
+            var meta = [String: JSON]()
+            if let statusCode = statusCode {
+                meta["status_code"] = JSON.int(statusCode)
+            }
+            if let message = message {
+                meta["message"] = JSON.string(message)
+            }
+            return !meta.isEmpty ? meta : nil
+        default:
+            return nil
         }
     }
 }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -41,7 +41,6 @@ public enum RestError {
 
     /// Generic HTTP error with a status code and description.
     case http(statusCode: Int?, message: String?)
-
 }
 
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -25,24 +25,21 @@ public enum RestError {
     /// No data was returned from the server.
     case noData
 
+    /// Failed to save the downloaded data.
+    /// The specified file may already exist or the disk may be full.
+    case saveData
+
     /// Failed to serialize value(s) to data.
-    case serializationError
+    case serialization
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
-    case encodingError
-
-    /// FileManager failed to handle the given file.
-    /// (The file may already exist or the disk may be full.)
-    case fileManagerError
-
-    /// Failed to load the given file.
-    case invalidFile
+    case encoding
 
     /// The request failed because the URL was malformed.
     case badURL
 
-    /// An HTTP error with a status code and description.
+    /// Generic HTTP error with a status code and description.
     case http(statusCode: Int, message: String)
 
 }
@@ -67,14 +64,12 @@ extension RestError: LocalizedError {
             return "No response was received from the server"
         case .noData:
             return "No data was returned by the server"
-        case .serializationError:
+        case .saveData:
+            return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
+        case .serialization:
             return "Failed to serialize the data"
-        case .encodingError:
+        case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
-        case .fileManagerError:
-            return "Failed the handle the provided file"
-        case .invalidFile:
-            return "Cannot load the provided file"
         case .badURL:
             return "Malformed URL"
         case .http(_, message: let message):

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -198,7 +198,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization)
+                    completionHandler(watsonResponse, RestError.serialization("response string"))
                     return
                 }
                 watsonResponse.result = string as? T
@@ -242,7 +242,7 @@ extension RestRequest {
                 watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(watsonResponse, nil)
             } catch {
-                completionHandler(nil, RestError.serialization)
+                completionHandler(nil, RestError.serialization("response JSON"))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -197,7 +197,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serializationError)
+                    completionHandler(watsonResponse, RestError.serialization)
                     return
                 }
                 watsonResponse.result = string as? T
@@ -310,9 +310,9 @@ extension RestRequest {
                     return
                 }
 
-                // ensure the response body was saved to a temporary location
+                // ensure that we can retrieve the downloaded data from its temporary location
                 guard let location = location else {
-                    completionHandler(response, RestError.invalidFile)
+                    completionHandler(response, RestError.noData)
                     return
                 }
 
@@ -321,7 +321,7 @@ extension RestRequest {
                     try FileManager.default.moveItem(at: location, to: destination)
                     completionHandler(response, nil)
                 } catch {
-                    completionHandler(response, RestError.fileManagerError)
+                    completionHandler(response, RestError.saveData)
                 }
             }
 

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -198,7 +198,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization("response string"))
+                    completionHandler(watsonResponse, RestError.serialization(values: "response string", metadata: nil))
                     return
                 }
                 watsonResponse.result = string as? T
@@ -242,7 +242,7 @@ extension RestRequest {
                 watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(watsonResponse, nil)
             } catch {
-                completionHandler(nil, RestError.serialization("response JSON"))
+                completionHandler(nil, RestError.serialization(values: "response JSON", metadata: nil))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -151,7 +151,7 @@ extension RestRequest {
                         completionHandler(data, response, serviceError)
                     } else {
                         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-                        let genericError = RestError.failure(response.statusCode, genericMessage)
+                        let genericError = RestError.http(statusCode: response.statusCode, message: genericMessage)
                         completionHandler(data, response, genericError)
                     }
                     return

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,4 +6,5 @@ XCTMain([
     testCase(AuthenticationTests.allTests),
     testCase(CodableExtensionsTests.allTests),
     testCase(JSONTests.allTests),
+    testCase(RestErrorTests.allTests),
 ])

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -31,7 +31,7 @@ class AuthenticationTests: XCTestCase {
         ("testIAMAuthentication", testIAMAuthentication),
     ]
 
-    internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
         return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -33,7 +33,7 @@ class AuthenticationTests: XCTestCase {
 
     internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.failure(response.statusCode, genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }
 
     var request = RestRequest(

--- a/Tests/RestKitTests/MultiPartFormDataTests.swift
+++ b/Tests/RestKitTests/MultiPartFormDataTests.swift
@@ -25,19 +25,9 @@ class MultiPartFormDataTests: XCTestCase {
         ("testSimpleFormData", testSimpleFormData),
         ("testFormData", testFormData),
         ("testFormDataFromURL", testFormDataFromURL),
-        ("testFormDataWithInvalidURL", testFormDataWithInvalidURL)
+        ("testFormDataWithInvalidURL", testFormDataWithInvalidURL),
     ]
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func loadResource(name: String, ext: String) -> URL {
         #if os(Linux)
         return URL(fileURLWithPath: "Tests/RestKitTests/Resources/" + name + "." + ext)

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -22,6 +22,7 @@ class RestErrorTests: XCTestCase {
     static var allTests = [
         ("testHTTPErrorStatusCode", testHTTPErrorStatusCode),
         ("testHTTPErrorMessage", testHTTPErrorMessage),
+        ("testHTTPErrorMetadata", testHTTPErrorMetadata),
     ]
 
     func testHTTPErrorStatusCode() {

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -1,0 +1,38 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+@testable import RestKit
+
+class RestErrorTests: XCTestCase {
+
+    static var allTests = [
+        ("testHTTPErrorStatusCode", testHTTPErrorStatusCode),
+        ("testHTTPErrorMessage", testHTTPErrorMessage),
+    ]
+
+    func testHTTPErrorStatusCode() {
+        let testStatusCode = 400
+        let httpError = RestError.http(statusCode: testStatusCode, message: "Success")
+        XCTAssertEqual(httpError.statusCode, testStatusCode)
+    }
+
+    func testHTTPErrorMessage() {
+        let testMessage = "Something went wrong"
+        let httpError = RestError.http(statusCode: 500, message: testMessage)
+        XCTAssertEqual(httpError.errorDescription, testMessage)
+    }
+}

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -27,12 +27,23 @@ class RestErrorTests: XCTestCase {
     func testHTTPErrorStatusCode() {
         let testStatusCode = 400
         let httpError = RestError.http(statusCode: testStatusCode, message: "Success")
+
         XCTAssertEqual(httpError.statusCode, testStatusCode)
     }
 
     func testHTTPErrorMessage() {
         let testMessage = "Something went wrong"
         let httpError = RestError.http(statusCode: 500, message: testMessage)
+
         XCTAssertEqual(httpError.errorDescription, testMessage)
+    }
+
+    func testHTTPErrorMetadata() {
+        let testStatusCode = 500
+        let testMessage = "Something went wrong"
+        let httpError = RestError.http(statusCode: testStatusCode, message: testMessage)
+
+        XCTAssertEqual(httpError.metadata!["status_code"]!, JSON.int(testStatusCode))
+        XCTAssertEqual(httpError.metadata!["message"]!, JSON.string(testMessage))
     }
 }


### PR DESCRIPTION
This is for the following issue: https://github.ibm.com/arf/planning-sdk-squad/issues/549

I've improved the error handling in RestKit, in preparation for changing the error handling done in the Swift SDK. In particular, I made `RestError` conform to the `LocalizedError` protocol, added a `statusCode` property, and cleaned up some of the cases.