### PR TITLE
Option to disable SSL verification

### DIFF
--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -92,6 +92,17 @@ public class BasicAuthentication: AuthenticationMethod {
         }
     }
 
+    public func authenticateWithoutToken(request: URLRequest, completionHandler: @escaping (URLRequest?, Error?) -> Void) {
+        var request = request
+        guard let data = (username + ":" + password).data(using: .utf8) else {
+            completionHandler(nil, RestError.serializationError)
+            return
+        }
+        let string = "Basic \(data.base64EncodedString())"
+        request.addValue(string, forHTTPHeaderField: "Authorization")
+        completionHandler(request, nil)
+    }
+
     private func getToken(completionHandler: @escaping (String?, Error?) -> Void) {
         // request a new access token if not present
         guard let token = token else {

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -394,9 +394,6 @@ public enum RestResult<T> {
 public class DisableSSLDelegate: NSObject, URLSessionDelegate {
     public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
 
-        print("\nCHALLENGE PROTECTION SPACE:")
-        print(challenge.protectionSpace)
-
         let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
         completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -385,3 +385,19 @@ public enum RestResult<T> {
     case success(T)
     case failure(Error)
 }
+
+/**
+ URLSession delegate that is used to bypass SSL certificate verification.
+
+ **IMPORTANT**: This can potentially cause dangerous security breaches, so use only if you are certain that you have taken necessary precautions.
+ */
+public class DisableSSLDelegate: NSObject, URLSessionDelegate {
+    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+
+        print("\nCHALLENGE PROTECTION SPACE:")
+        print(challenge.protectionSpace)
+
+        let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
+        completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
+    }
+}


### PR DESCRIPTION
Connecting to services on ICP requires disabling SSL certificate verification. This PR adds a `URLSessionDelegate` that can be used to circumvent this check.

See https://github.com/watson-developer-cloud/swift-sdk/pull/898 to see how this is implemented in the Swift SDK.