### PR TITLE
Capture and propagate decoding error info to the user

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
 		92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547735216BEFC8003C2829 /* RestErrorTests.swift */; };
 		92BF69BC213F4BD800FE6325 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* RestResponse.swift */; };
+		CA17C8DE2190E33400677CA7 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */; };
+		CA17C8E02191063800677CA7 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8DF2191063800677CA7 /* ResponseTests.swift */; };
 		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
 /* End PBXBuildFile section */
@@ -53,6 +55,8 @@
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
 		92547735216BEFC8003C2829 /* RestErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestErrorTests.swift; path = RestKitTests/RestErrorTests.swift; sourceTree = "<group>"; };
 		92BF69BB213F4BD800FE6325 /* RestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestResponse.swift; path = RestKit/RestResponse.swift; sourceTree = "<group>"; };
+		CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockURLProtocol.swift; path = RestKitTests/MockURLProtocol.swift; sourceTree = "<group>"; };
+		CA17C8DF2191063800677CA7 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResponseTests.swift; path = RestKitTests/ResponseTests.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -116,7 +120,9 @@
 				92048D7C212F5BA2004FD822 /* AuthenticationTests.swift */,
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
+				CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */,
 				CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */,
+				CA17C8DF2191063800677CA7 /* ResponseTests.swift */,
 				92547735216BEFC8003C2829 /* RestErrorTests.swift */,
 				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
@@ -278,6 +284,8 @@
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
 				92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */,
+				CA17C8E02191063800677CA7 /* ResponseTests.swift in Sources */,
+				CA17C8DE2190E33400677CA7 /* MockURLProtocol.swift in Sources */,
 				CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -214,8 +214,23 @@ extension RestRequest {
             do {
                 restResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(restResponse, nil)
+            } catch DecodingError.dataCorrupted(let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: dataCorrupted at \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.keyNotFound(let key, _) {
+                let values = "response JSON: key not found for \(key.stringValue)"
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.typeMismatch(_, let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: type mismatch for \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.valueNotFound(_, let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: value not found for \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON"))
+                completionHandler(nil, RestError.serialization(values: "response JSON " + error.localizedDescription))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -230,7 +230,7 @@ extension RestRequest {
                 let values = "response JSON: value not found for \(keyPath): " + context.debugDescription
                 completionHandler(nil, RestError.serialization(values: values))
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON " + error.localizedDescription))
+                completionHandler(nil, RestError.serialization(values: "response JSON: " + error.localizedDescription))
             }
         }
     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,5 +7,6 @@ XCTMain([
     testCase(CodableExtensionsTests.allTests),
     testCase(JSONTests.allTests),
     testCase(RestErrorTests.allTests),
+    testCase(ResponseTests.allTests),
     testCase(MultiPartFormDataTests.allTests),
 ])

--- a/Tests/RestKitTests/MockURLProtocol.swift
+++ b/Tests/RestKitTests/MockURLProtocol.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+/**
+ * MockURLProtocol from WWDC 2018 Session 417 Testing Tips & Tricks
+ */
+class MockURLProtocol: URLProtocol {
+
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            XCTFail("Received unexpected request with no handler set")
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // Don't delete this method!  Without it, your tests will crash
+        // in com.apple.CFNetwork.CustomProtocols
+    }
+
+}

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -1,0 +1,184 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import RestKit
+
+class ResponseTests: XCTestCase {
+
+    static var allTests = [
+        ("testDataCorruptedError", testDataCorruptedError),
+        ]
+
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+        let statusCode = response.statusCode
+        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
+    }
+
+    // MARK: Decoding errors
+
+    class Document : Codable {
+        let id: String
+        let name: String?
+        let status: DocumentStatus?
+    }
+
+    class DocumentStatus : Codable {
+        let created: Date?
+        let updated: Date?
+    }
+
+    func testDataCorruptedError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": \"12345\", \"status\": { \"created\": \"\" } }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_data_corrputed_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: dataCorrupted at status.created: Date string does not match format expected by formatter."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testKeyNotFoundError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"name\": \"A document with no id\"}".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_key_not_found_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: key not found for id"
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testTypeMismatchError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": \"12345\", \"status\": { \"updated\": 3.14159626 } }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_type_mismatch_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: type mismatch for status.updated: Expected to decode String but found a number instead."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testValueNotFoundError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": null, \"name\": \"document with null id\" }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_value_not_found_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: value not found for id: Expected String value but found null instead."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+}

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -19,33 +19,23 @@ import RestKit
 
 class ResponseTests: XCTestCase {
 
+    // Mock URLSession
+    var configuration: URLSessionConfiguration!
+    var mockSession: URLSession!
+
+    override func setUp() {
+        configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: configuration)
+    }
+
     static var allTests = [
         ("testDataCorruptedError", testDataCorruptedError),
-        ]
+    ]
 
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
-        let statusCode = response.statusCode
-        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
-    }
-
-    // MARK: Decoding errors
-
-    class Document : Codable {
-        let id: String
-        let name: String?
-        let status: DocumentStatus?
-    }
-
-    class DocumentStatus : Codable {
-        let created: Date?
-        let updated: Date?
-    }
+    // MARK: - Tests
 
     func testDataCorruptedError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -77,10 +67,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testKeyNotFoundError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -112,10 +98,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testTypeMismatchError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -147,10 +129,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testValueNotFoundError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -181,4 +159,22 @@ class ResponseTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+
+    // MARK: - Helpers
+
+    class Document : Codable {
+        let id: String
+        let name: String?
+        let status: DocumentStatus?
+    }
+
+    class DocumentStatus : Codable {
+        let created: Date?
+        let updated: Date?
+    }
+
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+        let statusCode = response.statusCode
+        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
+    }
 }

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -24,13 +24,16 @@ class ResponseTests: XCTestCase {
     var mockSession: URLSession!
 
     override func setUp() {
-        configuration = URLSessionConfiguration.ephemeral
+        configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         mockSession = URLSession(configuration: configuration)
     }
 
     static var allTests = [
         ("testDataCorruptedError", testDataCorruptedError),
+        ("testKeyNotFoundError", testKeyNotFoundError),
+        ("testTypeMismatchError", testTypeMismatchError),
+        ("testValueNotFoundError", testValueNotFoundError),
     ]
 
     // MARK: - Tests


### PR DESCRIPTION
This PR adds diagnostic information to RestErrors that result from exceptions that occur when attempting to decode a JSON response.  In particular, the specific key or keyPath that caused the error is included.