### PR TITLE
RestKit 2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10.1
 branches:
   only:
     - master
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild clean test -scheme RestKit -destination "platform=iOS Simulator,name=iPhone X,OS=11.3"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild clean test -scheme RestKit -destination "platform=iOS Simulator,name=iPhone X,OS=12.0"; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi

--- a/IBMWatsonRestKit.podspec
+++ b/IBMWatsonRestKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonRestKit'
-  s.version               = '1.3.0'
+  s.version               = '2.0.0'
   s.summary               = 'Networking layer for the IBM Watson Swift SDK'
   s.license               = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.homepage              = 'https://www.ibm.com/watson/'

--- a/IBMWatsonRestKit.podspec
+++ b/IBMWatsonRestKit.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                               'Mike Kistler'    => 'mkistler@us.ibm.com' }
 
   s.module_name           = 'RestKit'
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/restkit.git', :tag => s.version.to_s }
   
   s.source_files          = 'Sources/**/*.swift'

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ For more information on IBM Watson services, visit the [IBM Watson homepage](htt
 
 ## Requirements
 
-- iOS 8.0+
-- Xcode 9.0+
-- Swift 3.2+ or Swift 4.0+
+- Xcode 9.3+
+- Swift 4.1+
+- iOS 10.0+
 
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If your project does not yet have a Podfile, use the `pod init` command in the r
 use_frameworks!
 
 target 'MyApp' do
-    pod 'RestKit', '~> 1.0'
+    pod 'RestKit', '~> 2.0'
 end
 ```
 
@@ -60,7 +60,7 @@ $ brew install carthage
 If your project does not have a Cartfile yet, use the `touch Cartfile` command in the root directory of your project. To install RestKit using Carthage, add the following to your Cartfile. 
 
 ```
-github "watson-developer-cloud/restkit" ~> 1.0
+github "watson-developer-cloud/restkit" ~> 2.0
 ```
 
 Then run the following command to build the dependencies and frameworks:
@@ -77,7 +77,7 @@ Add the following to your `Package.swift` file to identify RestKit as a dependen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/watson-developer-cloud/restkit", from: "1.0.0")
+    .package(url: "https://github.com/watson-developer-cloud/restkit", from: "2.0")
 ]
 ```
 

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
 		92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547735216BEFC8003C2829 /* RestErrorTests.swift */; };
-		92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */; };
+		92BF69BC213F4BD800FE6325 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* RestResponse.swift */; };
 		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
 /* End PBXBuildFile section */
@@ -52,7 +52,7 @@
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
 		92547735216BEFC8003C2829 /* RestErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestErrorTests.swift; path = RestKitTests/RestErrorTests.swift; sourceTree = "<group>"; };
-		92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WatsonResponse.swift; path = RestKit/WatsonResponse.swift; sourceTree = "<group>"; };
+		92BF69BB213F4BD800FE6325 /* RestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestResponse.swift; path = RestKit/RestResponse.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -104,7 +104,7 @@
 				92048D85212F5BEE004FD822 /* RestError.swift */,
 				92048D81212F5BEE004FD822 /* RestRequest.swift */,
 				92048D84212F5BEE004FD822 /* RestUtilities.swift */,
-				92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */,
+				92BF69BB213F4BD800FE6325 /* RestResponse.swift */,
 				92048D60212F4B1F004FD822 /* Supporting Files */,
 			);
 			path = Sources;
@@ -262,7 +262,7 @@
 			files = (
 				92048D8B212F5BEE004FD822 /* RestUtilities.swift in Sources */,
 				92048D8E212F5BEE004FD822 /* JSON.swift in Sources */,
-				92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */,
+				92BF69BC213F4BD800FE6325 /* RestResponse.swift in Sources */,
 				92048D8C212F5BEE004FD822 /* RestError.swift in Sources */,
 				92048D89212F5BEE004FD822 /* MultipartFormData.swift in Sources */,
 				92048D88212F5BEE004FD822 /* RestRequest.swift in Sources */,

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		92048D8C212F5BEE004FD822 /* RestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D85212F5BEE004FD822 /* RestError.swift */; };
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
+		92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		92048D85212F5BEE004FD822 /* RestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RestError.swift; path = RestKit/RestError.swift; sourceTree = "<group>"; };
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
+		92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WatsonResponse.swift; path = RestKit/WatsonResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 				92048D85212F5BEE004FD822 /* RestError.swift */,
 				92048D81212F5BEE004FD822 /* RestRequest.swift */,
 				92048D84212F5BEE004FD822 /* RestUtilities.swift */,
+				92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */,
 				92048D60212F4B1F004FD822 /* Supporting Files */,
 			);
 			path = Sources;
@@ -241,6 +244,7 @@
 			files = (
 				92048D8B212F5BEE004FD822 /* RestUtilities.swift in Sources */,
 				92048D8E212F5BEE004FD822 /* JSON.swift in Sources */,
+				92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */,
 				92048D8C212F5BEE004FD822 /* RestError.swift in Sources */,
 				92048D89212F5BEE004FD822 /* MultipartFormData.swift in Sources */,
 				92048D88212F5BEE004FD822 /* RestRequest.swift in Sources */,

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		92048D8C212F5BEE004FD822 /* RestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D85212F5BEE004FD822 /* RestError.swift */; };
 		92048D8D212F5BEE004FD822 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D86212F5BEE004FD822 /* Authentication.swift */; };
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
+		92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547735216BEFC8003C2829 /* RestErrorTests.swift */; };
 		92BF69BC213F4BD800FE6325 /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */; };
 		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
@@ -50,6 +51,7 @@
 		92048D85212F5BEE004FD822 /* RestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RestError.swift; path = RestKit/RestError.swift; sourceTree = "<group>"; };
 		92048D86212F5BEE004FD822 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = RestKit/Authentication.swift; sourceTree = "<group>"; };
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
+		92547735216BEFC8003C2829 /* RestErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestErrorTests.swift; path = RestKitTests/RestErrorTests.swift; sourceTree = "<group>"; };
 		92BF69BB213F4BD800FE6325 /* WatsonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WatsonResponse.swift; path = RestKit/WatsonResponse.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
 				CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */,
+				92547735216BEFC8003C2829 /* RestErrorTests.swift */,
 				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
 			);
@@ -274,6 +277,7 @@
 			files = (
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
+				92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */,
 				CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		92048D8E212F5BEE004FD822 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92048D87212F5BEE004FD822 /* JSON.swift */; };
 		92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547735216BEFC8003C2829 /* RestErrorTests.swift */; };
 		92BF69BC213F4BD800FE6325 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69BB213F4BD800FE6325 /* RestResponse.swift */; };
+		CA17C8DE2190E33400677CA7 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */; };
+		CA17C8E02191063800677CA7 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8DF2191063800677CA7 /* ResponseTests.swift */; };
 		CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		CA54276D2155763E0035F8B6 /* TestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CA54276B215574380035F8B6 /* TestData.txt */; };
 /* End PBXBuildFile section */
@@ -53,6 +55,8 @@
 		92048D87212F5BEE004FD822 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSON.swift; path = RestKit/JSON.swift; sourceTree = "<group>"; };
 		92547735216BEFC8003C2829 /* RestErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestErrorTests.swift; path = RestKitTests/RestErrorTests.swift; sourceTree = "<group>"; };
 		92BF69BB213F4BD800FE6325 /* RestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestResponse.swift; path = RestKit/RestResponse.swift; sourceTree = "<group>"; };
+		CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockURLProtocol.swift; path = RestKitTests/MockURLProtocol.swift; sourceTree = "<group>"; };
+		CA17C8DF2191063800677CA7 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResponseTests.swift; path = RestKitTests/ResponseTests.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -116,7 +120,9 @@
 				92048D7C212F5BA2004FD822 /* AuthenticationTests.swift */,
 				92048D7D212F5BA2004FD822 /* CodableExtensionsTests.swift */,
 				92048D7B212F5BA2004FD822 /* JSONTests.swift */,
+				CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */,
 				CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */,
+				CA17C8DF2191063800677CA7 /* ResponseTests.swift */,
 				92547735216BEFC8003C2829 /* RestErrorTests.swift */,
 				CA54276A215573F60035F8B6 /* Resources */,
 				92048D61212F4B47004FD822 /* Supporting Files */,
@@ -278,6 +284,8 @@
 				92048D7E212F5BA2004FD822 /* JSONTests.swift in Sources */,
 				92048D7F212F5BA2004FD822 /* AuthenticationTests.swift in Sources */,
 				92547736216BEFC8003C2829 /* RestErrorTests.swift in Sources */,
+				CA17C8E02191063800677CA7 /* ResponseTests.swift in Sources */,
+				CA17C8DE2190E33400677CA7 /* MockURLProtocol.swift in Sources */,
 				CA542769215558740035F8B6 /* MultiPartFormDataTests.swift in Sources */,
 				92048D80212F5BA2004FD822 /* CodableExtensionsTests.swift in Sources */,
 			);

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -87,7 +87,7 @@ public class BasicAuthentication: AuthenticationMethod {
                 request.addValue(token, forHTTPHeaderField: "X-Watson-Authorization-Token")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }
@@ -106,7 +106,7 @@ public class BasicAuthentication: AuthenticationMethod {
     private func requestToken(completionHandler: @escaping (String?, Error?) -> Void) {
 
         guard let tokenURL = tokenURL else {
-            completionHandler(nil, RestError.failure(400, "Websocket authentication requires tokenURL"))
+            completionHandler(nil, RestError.http(statusCode: 400, message: "Websocket authentication requires tokenURL"))
             return
         }
 
@@ -152,7 +152,7 @@ public class BasicAuthentication: AuthenticationMethod {
             }
         } catch { /* no need to catch -- falls back to default description */ }
 
-        return RestError.failure(code, message)
+        return RestError.http(statusCode: code, message: message)
     }
 }
 
@@ -231,7 +231,7 @@ public class IAMAuthentication: AuthenticationMethod {
 
     internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.failure(response.statusCode, genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }
 
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
@@ -241,7 +241,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.headerParameters["Authorization"] = "Bearer \(token.accessToken)"
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }
@@ -253,7 +253,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.failure(400, "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
             }
         }
     }

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serialization)
+            completionHandler(nil, RestError.serialization("username and password"))
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -298,7 +298,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, RestError?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serialization); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization("IAM token")); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serialization("username and password"))
+            completionHandler(nil, RestError.serialization(values: "username and password", metadata: nil))
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -298,7 +298,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, RestError?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serialization("IAM token")); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization(values: "IAM token", metadata: nil)); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -119,7 +119,7 @@ public class BasicAuthentication: AuthenticationMethod {
             url: tokenURL,
             headerParameters: [:])
 
-        request.response { (response: WatsonResponse<String>?, error) in
+        request.response { (response: RestResponse<String>?, error) in
             guard error == nil else {
                 let restError = RestError.http(statusCode: response?.statusCode, message: "\(String(describing: error))", metadata: nil)
                 completionHandler(nil, restError)
@@ -288,7 +288,7 @@ public class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+        request.responseObject { (response: RestResponse<IAMToken>?, error) in
             guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
                 return
@@ -310,7 +310,7 @@ public class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+        request.responseObject { (response: RestResponse<IAMToken>?, error) in
             guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
                 return

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -119,14 +119,17 @@ public class BasicAuthentication: AuthenticationMethod {
             url: tokenURL,
             headerParameters: [:])
 
-        request.responseString { response in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.response { (response: WatsonResponse<String>?, error) in
+            guard error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            guard let token = response?.result else {
+                completionHandler(nil, RestError.noData)
+                return
+            }
+            self.token = token
+            completionHandler(token, nil)
         }
     }
 
@@ -284,14 +287,12 @@ public class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+            guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            completionHandler(token, nil)
         }
     }
 
@@ -308,14 +309,12 @@ public class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+            guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            completionHandler(token, nil)
         }
     }
 }

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serialization(values: "username and password", metadata: nil))
+            completionHandler(nil, RestError.serialization(values: "username and password"))
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -87,7 +87,7 @@ public class BasicAuthentication: AuthenticationMethod {
                 request.addValue(token, forHTTPHeaderField: "X-Watson-Authorization-Token")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
             }
         }
     }
@@ -106,7 +106,7 @@ public class BasicAuthentication: AuthenticationMethod {
     private func requestToken(completionHandler: @escaping (String?, RestError?) -> Void) {
 
         guard let tokenURL = tokenURL else {
-            completionHandler(nil, RestError.http(statusCode: 400, message: "Websocket authentication requires tokenURL"))
+            completionHandler(nil, RestError.http(statusCode: 400, message: "Websocket authentication requires tokenURL", metadata: nil))
             return
         }
 
@@ -121,7 +121,7 @@ public class BasicAuthentication: AuthenticationMethod {
 
         request.response { (response: WatsonResponse<String>?, error) in
             guard error == nil else {
-                let restError = RestError.http(statusCode: response?.statusCode, message: "\(String(describing: error))")
+                let restError = RestError.http(statusCode: response?.statusCode, message: "\(String(describing: error))", metadata: nil)
                 completionHandler(nil, restError)
                 return
             }
@@ -153,7 +153,7 @@ public class BasicAuthentication: AuthenticationMethod {
             }
         } catch { /* no need to catch -- falls back to default description */ }
 
-        return RestError.http(statusCode: code, message: message)
+        return RestError.http(statusCode: code, message: message, metadata: nil)
     }
 }
 
@@ -232,7 +232,7 @@ public class IAMAuthentication: AuthenticationMethod {
 
     internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.http(statusCode: response.statusCode, message: genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage, metadata: nil)
     }
 
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, RestError?) -> Void) {
@@ -242,7 +242,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.headerParameters["Authorization"] = "Bearer \(token.accessToken)"
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
             }
         }
     }
@@ -254,7 +254,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
                 completionHandler(request, nil)
             } else {
-                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error"))
+                completionHandler(nil, error ?? RestError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
             }
         }
     }
@@ -298,7 +298,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, RestError?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serialization(values: "IAM token", metadata: nil)); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization(values: "IAM token")); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -71,7 +71,7 @@ public class BasicAuthentication: AuthenticationMethod {
     public func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
         var request = request
         guard let data = (username + ":" + password).data(using: .utf8) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization)
             return
         }
         let string = "Basic \(data.base64EncodedString())"
@@ -297,7 +297,7 @@ public class IAMAuthentication: AuthenticationMethod {
     }
 
     private func refreshToken(completionHandler: @escaping (IAMToken?, Error?) -> Void) {
-        guard let token = token else { completionHandler(nil, RestError.serializationError); return }
+        guard let token = token else { completionHandler(nil, RestError.serialization); return }
         let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
         let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
         let request = RestRequest(

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -73,10 +73,8 @@ public class MultipartFormData {
             let bodyBoundary: Data
             if index == 0 {
                 bodyBoundary = initialBoundary
-            } else if index != 0 {
-                bodyBoundary = encapsulatedBoundary
             } else {
-                throw RestError.encoding
+                bodyBoundary = encapsulatedBoundary
             }
 
             data.append(bodyBoundary)
@@ -129,7 +127,7 @@ internal struct BodyPart {
         var result = Data()
         let headerString = header
         guard let header = headerString.data(using: .utf8) else {
-            throw RestError.encoding
+            throw RestError.serialization(values: headerString, metadata: nil)
         }
         result.append(header)
         result.append(data)

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serialization(values: "file contents", metadata: nil)
+            throw RestError.serialization(values: "file contents")
         }
     }
 
@@ -127,7 +127,7 @@ internal struct BodyPart {
         var result = Data()
         let headerString = header
         guard let header = headerString.data(using: .utf8) else {
-            throw RestError.serialization(values: headerString, metadata: nil)
+            throw RestError.serialization(values: headerString)
         }
         result.append(header)
         result.append(data)

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serialization
+            throw RestError.serialization("file contents")
         }
     }
 

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serializationError
+            throw RestError.serialization
         }
     }
 
@@ -76,7 +76,7 @@ public class MultipartFormData {
             } else if index != 0 {
                 bodyBoundary = encapsulatedBoundary
             } else {
-                throw RestError.encodingError
+                throw RestError.encoding
             }
 
             data.append(bodyBoundary)
@@ -129,7 +129,7 @@ internal struct BodyPart {
         var result = Data()
         let headerString = header
         guard let header = headerString.data(using: .utf8) else {
-            throw RestError.encodingError
+            throw RestError.encoding
         }
         result.append(header)
         result.append(data)

--- a/Sources/RestKit/MultipartFormData.swift
+++ b/Sources/RestKit/MultipartFormData.swift
@@ -63,7 +63,7 @@ public class MultipartFormData {
             let bodyPart = BodyPart(key: withName, data: data, mimeType: mimeType, fileName: fileURL.lastPathComponent)
             bodyParts.append(bodyPart)
         } else {
-            throw RestError.serialization("file contents")
+            throw RestError.serialization(values: "file contents", metadata: nil)
         }
     }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -40,7 +40,7 @@ public enum RestError {
     case badURL
 
     /// Generic HTTP error with a status code and description.
-    case http(statusCode: Int?, message: String?, metadata: [String: JSON]?)
+    case http(statusCode: Int?, message: String?, metadata: [String: Any]?)
 }
 
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -34,7 +34,7 @@ public enum RestError {
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
-    case encoding(path: String)
+    case urlEncoding(path: String)
 
     /// The request failed because the URL was malformed.
     case badURL
@@ -56,7 +56,7 @@ extension RestError: LocalizedError {
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
         case .serialization(let values):
             return "Failed to serialize " + values
-        case .encoding(let path):
+        case .urlEncoding(let path):
             return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -43,7 +43,7 @@ public enum RestError {
     case badURL
 
     /// An HTTP error with a status code and description.
-    case failure(Int, String)
+    case http(statusCode: Int, message: String)
 
 }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// An error from processing a network request or response.
-public enum RestError: Error {
+public enum RestError {
 
     /// No response was received from the server.
     case noResponse
@@ -45,4 +45,40 @@ public enum RestError: Error {
     /// An HTTP error with a status code and description.
     case failure(Int, String)
 
+}
+
+
+extension RestError: LocalizedError {
+
+    /// The status code returned by the server
+    public var statusCode: Int? {
+        switch self {
+        case .http(statusCode: let statusCode, _):
+            return statusCode
+        default:
+            return nil
+        }
+    }
+
+    /// A localized message describing what error occurred
+    public var errorDescription: String? {
+        switch self {
+        case .noResponse:
+            return "No response was received from the server"
+        case .noData:
+            return "No data was returned by the server"
+        case .serializationError:
+            return "Failed to serialize the data"
+        case .encodingError:
+            return "Failed to replace special characters in the URL path with percent encoded characters"
+        case .fileManagerError:
+            return "Failed the handle the provided file"
+        case .invalidFile:
+            return "Cannot load the provided file"
+        case .badURL:
+            return "Malformed URL"
+        case .http(_, message: let message):
+            return message
+        }
+    }
 }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -30,7 +30,7 @@ public enum RestError {
     case saveData
 
     /// Failed to serialize value(s) to data.
-    case serialization
+    case serialization(String)
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
@@ -66,8 +66,8 @@ extension RestError: LocalizedError {
             return "No data was returned by the server"
         case .saveData:
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
-        case .serialization:
-            return "Failed to serialize the data"
+        case .serialization(let values):
+            return "Failed to serialize " + values
         case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
         case .badURL:

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -40,7 +40,7 @@ public enum RestError {
     case badURL
 
     /// Generic HTTP error with a status code and description.
-    case http(statusCode: Int, message: String)
+    case http(statusCode: Int?, message: String?)
 
 }
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -34,7 +34,7 @@ public enum RestError {
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
-    case encoding
+    case encoding(path: String)
 
     /// The request failed because the URL was malformed.
     case badURL
@@ -68,8 +68,8 @@ extension RestError: LocalizedError {
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
         case .serialization(let values, _):
             return "Failed to serialize " + values
-        case .encoding:
-            return "Failed to replace special characters in the URL path with percent encoded characters"
+        case .encoding(let path):
+            return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"
         case .http(_, message: let message):

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -30,7 +30,7 @@ public enum RestError {
     case saveData
 
     /// Failed to serialize value(s) to data.
-    case serialization(String)
+    case serialization(values: String, metadata: [String: JSON]?)
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
@@ -66,7 +66,7 @@ extension RestError: LocalizedError {
             return "No data was returned by the server"
         case .saveData:
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
-        case .serialization(let values):
+        case .serialization(let values, _):
             return "Failed to serialize " + values
         case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
@@ -74,6 +74,26 @@ extension RestError: LocalizedError {
             return "Malformed URL"
         case .http(_, message: let message):
             return message
+        }
+    }
+
+    /// Contains additional information associated with the error
+    /// Currently only supported for `RestError.serialization` and `RestError.http`
+    public var metadata: [String: JSON]? {
+        switch self {
+        case .serialization(_, let metadata):
+            return metadata
+        case .http(let statusCode, let message):
+            var meta = [String: JSON]()
+            if let statusCode = statusCode {
+                meta["status_code"] = JSON.int(statusCode)
+            }
+            if let message = message {
+                meta["message"] = JSON.string(message)
+            }
+            return !meta.isEmpty ? meta : nil
+        default:
+            return nil
         }
     }
 }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -30,7 +30,7 @@ public enum RestError {
     case saveData
 
     /// Failed to serialize value(s) to data.
-    case serialization(values: String, metadata: [String: JSON]?)
+    case serialization(values: String)
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
@@ -40,23 +40,12 @@ public enum RestError {
     case badURL
 
     /// Generic HTTP error with a status code and description.
-    case http(statusCode: Int?, message: String?)
+    case http(statusCode: Int?, message: String?, metadata: [String: JSON]?)
 }
 
 
 extension RestError: LocalizedError {
 
-    /// The status code returned by the server
-    public var statusCode: Int? {
-        switch self {
-        case .http(statusCode: let statusCode, _):
-            return statusCode
-        default:
-            return nil
-        }
-    }
-
-    /// A localized message describing what error occurred
     public var errorDescription: String? {
         switch self {
         case .noResponse:
@@ -65,34 +54,14 @@ extension RestError: LocalizedError {
             return "No data was returned by the server"
         case .saveData:
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
-        case .serialization(let values, _):
+        case .serialization(let values):
             return "Failed to serialize " + values
         case .encoding(let path):
             return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"
-        case .http(_, message: let message):
+        case .http(_, message: let message, _):
             return message
-        }
-    }
-
-    /// Contains additional information associated with the error
-    /// Currently only supported for `RestError.serialization` and `RestError.http`
-    public var metadata: [String: JSON]? {
-        switch self {
-        case .serialization(_, let metadata):
-            return metadata
-        case .http(let statusCode, let message):
-            var meta = [String: JSON]()
-            if let statusCode = statusCode {
-                meta["status_code"] = JSON.int(statusCode)
-            }
-            if let message = message {
-                meta["message"] = JSON.string(message)
-            }
-            return !meta.isEmpty ? meta : nil
-        default:
-            return nil
         }
     }
 }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -41,6 +41,9 @@ public enum RestError {
 
     /// Generic HTTP error with a status code and description.
     case http(statusCode: Int?, message: String?, metadata: [String: Any]?)
+
+    /// Error that does not fall under any other `RestError` category
+    case other(message: String?)
 }
 
 
@@ -60,7 +63,9 @@ extension RestError: LocalizedError {
             return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"
-        case .http(_, message: let message, _):
+        case .http(_, let message, _):
+            return message
+        case .other(let message):
             return message
         }
     }

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -41,7 +41,6 @@ public enum RestError {
 
     /// Generic HTTP error with a status code and description.
     case http(statusCode: Int?, message: String?)
-
 }
 
 

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -25,24 +25,21 @@ public enum RestError {
     /// No data was returned from the server.
     case noData
 
+    /// Failed to save the downloaded data.
+    /// The specified file may already exist or the disk may be full.
+    case saveData
+
     /// Failed to serialize value(s) to data.
-    case serializationError
+    case serialization
 
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
-    case encodingError
-
-    /// FileManager failed to handle the given file.
-    /// (The file may already exist or the disk may be full.)
-    case fileManagerError
-
-    /// Failed to load the given file.
-    case invalidFile
+    case encoding
 
     /// The request failed because the URL was malformed.
     case badURL
 
-    /// An HTTP error with a status code and description.
+    /// Generic HTTP error with a status code and description.
     case http(statusCode: Int, message: String)
 
 }
@@ -67,14 +64,12 @@ extension RestError: LocalizedError {
             return "No response was received from the server"
         case .noData:
             return "No data was returned by the server"
-        case .serializationError:
+        case .saveData:
+            return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
+        case .serialization:
             return "Failed to serialize the data"
-        case .encodingError:
+        case .encoding:
             return "Failed to replace special characters in the URL path with percent encoded characters"
-        case .fileManagerError:
-            return "Failed the handle the provided file"
-        case .invalidFile:
-            return "Cannot load the provided file"
         case .badURL:
             return "Malformed URL"
         case .http(_, message: let message):

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -140,7 +140,7 @@ extension RestRequest {
 
                 // ensure there is no underlying error
                 guard error == nil else {
-                    let restError = RestError.http(statusCode: response.statusCode, message: "\(String(describing: error))")
+                    let restError = RestError.http(statusCode: response.statusCode, message: "\(String(describing: error))", metadata: nil)
                     completionHandler(data, response, restError)
                     return
                 }
@@ -152,7 +152,7 @@ extension RestRequest {
                         completionHandler(data, response, serviceError)
                     } else {
                         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-                        let genericError = RestError.http(statusCode: response.statusCode, message: genericMessage)
+                        let genericError = RestError.http(statusCode: response.statusCode, message: genericMessage, metadata: nil)
                         completionHandler(data, response, genericError)
                     }
                     return
@@ -198,7 +198,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization(values: "response string", metadata: nil))
+                    completionHandler(watsonResponse, RestError.serialization(values: "response string"))
                     return
                 }
                 watsonResponse.result = string as? T
@@ -242,7 +242,7 @@ extension RestRequest {
                 watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(watsonResponse, nil)
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON", metadata: nil))
+                completionHandler(nil, RestError.serialization(values: "response JSON"))
             }
         }
     }
@@ -307,7 +307,7 @@ extension RestRequest {
 
                 // ensure there is no underlying error
                 guard error == nil else {
-                    let restError = RestError.http(statusCode: response.statusCode, message: "\(String(describing: error))")
+                    let restError = RestError.http(statusCode: response.statusCode, message: "\(String(describing: error))", metadata: nil)
                     completionHandler(response, restError)
                     return
                 }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -20,38 +20,9 @@ import Foundation
 
 public struct RestRequest {
 
-    // TODO: For RestKit version 2.0, remove the setter. This should only be set by the Watson Swift SDK.
-    // This needs to stay until 2.0 because Carthage will cause it to break with Watson Swift SDK v0.33.
     /// The "User-Agent" header that will be sent with every network request
     /// This can include information such as the operating system and the SDK/framework calling this API
-    public static var userAgent: String = {
-        let sdk = "watson-apis-swift-sdk"
-
-        let operatingSystem: String = {
-            #if os(iOS)
-            return "iOS"
-            #elseif os(watchOS)
-            return "watchOS"
-            #elseif os(tvOS)
-            return "tvOS"
-            #elseif os(macOS)
-            return "macOS"
-            #elseif os(Linux)
-            return "Linux"
-            #else
-            return "Unknown"
-            #endif
-        }()
-        let operatingSystemVersion: String = {
-            // swiftlint:disable:next identifier_name
-            let os = ProcessInfo.processInfo.operatingSystemVersion
-            return "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
-        }()
-        return "\(sdk)/\(sdkVersion) \(operatingSystem)/\(operatingSystemVersion)"
-    }()
-
-    // TODO: Remove this in RestKit version 2.0
-    public static var sdkVersion: String = "0.33.0"
+    public static var userAgent: String?
 
     private let session: URLSession
     internal var authMethod: AuthenticationMethod
@@ -95,7 +66,9 @@ public struct RestRequest {
         var request = URLRequest(url: urlWithQuery)
         request.httpMethod = method
         request.httpBody = messageBody
-        request.setValue(RestRequest.userAgent, forHTTPHeaderField: "User-Agent")
+        if let userAgentHeader = RestRequest.userAgent {
+            request.setValue(userAgentHeader, forHTTPHeaderField: "User-Agent")
+        }
         headerParameters.forEach { (key, value) in request.setValue(value, forHTTPHeaderField: key) }
         return request
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -173,7 +173,7 @@ extension RestRequest {
      - completionHandler: The completion handler to call when the request is complete.
      */
     public func response<T>(
-        completionHandler: @escaping (WatsonResponse<T>?, RestError?) -> Void)
+        completionHandler: @escaping (RestResponse<T>?, RestError?) -> Void)
     {
         // execute the request
         execute { data, response, error in
@@ -184,31 +184,31 @@ extension RestRequest {
                 return
             }
 
-            var watsonResponse = WatsonResponse<T>(response: response)
+            var restResponse = RestResponse<T>(response: response)
 
             // ensure there is data to parse
             guard let data = data else {
-                completionHandler(watsonResponse, RestError.noData)
+                completionHandler(restResponse, RestError.noData)
                 return
             }
 
             if T.self == Data.self {
                 // pass thru the raw data
-                watsonResponse.result = data as? T
+                restResponse.result = data as? T
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization(values: "response string"))
+                    completionHandler(restResponse, RestError.serialization(values: "response string"))
                     return
                 }
-                watsonResponse.result = string as? T
+                restResponse.result = string as? T
             } else {
                 // no other supported types
-                watsonResponse.result = nil
+                restResponse.result = nil
             }
 
             // execute completion handler
-            completionHandler(watsonResponse, nil)
+            completionHandler(restResponse, nil)
         }
     }
 
@@ -218,7 +218,7 @@ extension RestRequest {
      - completionHandler: The completion handler to call when the request is complete.
      */
     public func responseObject<T: Decodable>(
-        completionHandler: @escaping (WatsonResponse<T>?, RestError?) -> Void)
+        completionHandler: @escaping (RestResponse<T>?, RestError?) -> Void)
     {
         // execute the request
         execute { data, response, error in
@@ -229,18 +229,18 @@ extension RestRequest {
                 return
             }
 
-            var watsonResponse = WatsonResponse<T>(response: response)
+            var restResponse = RestResponse<T>(response: response)
 
             // ensure there is data to parse
             guard let data = data else {
-                completionHandler(watsonResponse, RestError.noData)
+                completionHandler(restResponse, RestError.noData)
                 return
             }
 
             // parse response body as a JSONobject
             do {
-                watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
-                completionHandler(watsonResponse, nil)
+                restResponse.result = try JSON.decoder.decode(T.self, from: data)
+                completionHandler(restResponse, nil)
             } catch {
                 completionHandler(nil, RestError.serialization(values: "response JSON"))
             }
@@ -253,7 +253,7 @@ extension RestRequest {
      - completionHandler: The completion handler to call when the request is complete.
      */
     public func responseVoid(
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (RestResponse<Void>?, RestError?) -> Void)
     {
         // execute the request
         execute { _, response, error in
@@ -264,10 +264,10 @@ extension RestRequest {
                 return
             }
 
-            let watsonResponse = WatsonResponse<Void>(response: response)
+            let restResponse = RestResponse<Void>(response: response)
 
             // execute completion handler
-            completionHandler(watsonResponse, nil)
+            completionHandler(restResponse, nil)
         }
     }
 

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -198,7 +198,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization)
+                    completionHandler(watsonResponse, RestError.serialization("response string"))
                     return
                 }
                 watsonResponse.result = string as? T
@@ -242,7 +242,7 @@ extension RestRequest {
                 watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(watsonResponse, nil)
             } catch {
-                completionHandler(nil, RestError.serialization)
+                completionHandler(nil, RestError.serialization("response JSON"))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -197,7 +197,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serializationError)
+                    completionHandler(watsonResponse, RestError.serialization)
                     return
                 }
                 watsonResponse.result = string as? T
@@ -310,9 +310,9 @@ extension RestRequest {
                     return
                 }
 
-                // ensure the response body was saved to a temporary location
+                // ensure that we can retrieve the downloaded data from its temporary location
                 guard let location = location else {
-                    completionHandler(response, RestError.invalidFile)
+                    completionHandler(response, RestError.noData)
                     return
                 }
 
@@ -321,7 +321,7 @@ extension RestRequest {
                     try FileManager.default.moveItem(at: location, to: destination)
                     completionHandler(response, nil)
                 } catch {
-                    completionHandler(response, RestError.fileManagerError)
+                    completionHandler(response, RestError.saveData)
                 }
             }
 

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -198,7 +198,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(watsonResponse, RestError.serialization("response string"))
+                    completionHandler(watsonResponse, RestError.serialization(values: "response string", metadata: nil))
                     return
                 }
                 watsonResponse.result = string as? T
@@ -242,7 +242,7 @@ extension RestRequest {
                 watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(watsonResponse, nil)
             } catch {
-                completionHandler(nil, RestError.serialization("response JSON"))
+                completionHandler(nil, RestError.serialization(values: "response JSON", metadata: nil))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -151,7 +151,7 @@ extension RestRequest {
                         completionHandler(data, response, serviceError)
                     } else {
                         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-                        let genericError = RestError.failure(response.statusCode, genericMessage)
+                        let genericError = RestError.http(statusCode: response.statusCode, message: genericMessage)
                         completionHandler(data, response, genericError)
                     }
                     return

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -214,8 +214,23 @@ extension RestRequest {
             do {
                 restResponse.result = try JSON.decoder.decode(T.self, from: data)
                 completionHandler(restResponse, nil)
+            } catch DecodingError.dataCorrupted(let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: dataCorrupted at \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.keyNotFound(let key, _) {
+                let values = "response JSON: key not found for \(key.stringValue)"
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.typeMismatch(_, let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: type mismatch for \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
+            } catch DecodingError.valueNotFound(_, let context) {
+                let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
+                let values = "response JSON: value not found for \(keyPath): " + context.debugDescription
+                completionHandler(nil, RestError.serialization(values: values))
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON"))
+                completionHandler(nil, RestError.serialization(values: "response JSON " + error.localizedDescription))
             }
         }
     }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -106,11 +106,11 @@ public struct RestRequest {
 extension RestRequest {
 
     /**
-     Execute this request. (This is the main response function and is called by many of the functions below.)
+     Execute this request. (This is called by many of the functions below.)
 
      - completionHandler: The completion handler to call when the request is complete.
      */
-    public func response(
+    internal func execute(
         completionHandler: @escaping (Data?, HTTPURLResponse?, Error?) -> Void)
     {
         // add authentication credentials to the request
@@ -171,33 +171,43 @@ extension RestRequest {
 
      - completionHandler: The completion handler to call when the request is complete.
      */
-    public func responseData(
-        completionHandler: @escaping (RestResponse<Data>) -> Void)
+    public func response<T>(
+        completionHandler: @escaping (WatsonResponse<T>?, Error?) -> Void)
     {
         // execute the request
-        response { data, response, error in
+        execute { data, response, error in
 
             // ensure there is no underlying error
-            guard error == nil else {
-                // swiftlint:disable:next force_unwrapping
-                let result = RestResult<Data>.failure(error!)
-                let dataResponse = RestResponse(response: response, data: data, result: result)
-                completionHandler(dataResponse)
+            guard let response = response, error == nil else {
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
+
+            var watsonResponse = WatsonResponse<T>(response: response)
 
             // ensure there is data to parse
             guard let data = data else {
-                let result = RestResult<Data>.failure(RestError.noData)
-                let dataResponse = RestResponse(response: response, data: nil, result: result)
-                completionHandler(dataResponse)
+                completionHandler(watsonResponse, RestError.noData)
                 return
             }
 
+            if T.self == Data.self {
+                // pass thru the raw data
+                watsonResponse.result = data as? T
+            } else if T.self == String.self {
+                // parse data as a string
+                guard let string = String(data: data, encoding: .utf8) else {
+                    completionHandler(watsonResponse, RestError.serializationError)
+                    return
+                }
+                watsonResponse.result = string as? T
+            } else {
+                // no other supported types
+                watsonResponse.result = nil
+            }
+
             // execute completion handler
-            let result = RestResult.success(data)
-            let dataResponse = RestResponse(response: response, data: data, result: result)
-            completionHandler(dataResponse)
+            completionHandler(watsonResponse, nil)
         }
     }
 
@@ -207,83 +217,32 @@ extension RestRequest {
      - completionHandler: The completion handler to call when the request is complete.
      */
     public func responseObject<T: Decodable>(
-        completionHandler: @escaping (RestResponse<T>) -> Void)
+        completionHandler: @escaping (WatsonResponse<T>?, Error?) -> Void)
     {
         // execute the request
-        response { data, response, error in
+        execute { data, response, error in
 
             // ensure there is no underlying error
-            guard error == nil else {
-                // swiftlint:disable:next force_unwrapping
-                let result = RestResult<T>.failure(error!)
-                let dataResponse = RestResponse(response: response, data: data, result: result)
-                completionHandler(dataResponse)
+            guard let response = response, error == nil else {
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
+
+            var watsonResponse = WatsonResponse<T>(response: response)
 
             // ensure there is data to parse
             guard let data = data else {
-                let result = RestResult<T>.failure(RestError.noData)
-                let dataResponse = RestResponse(response: response, data: nil, result: result)
-                completionHandler(dataResponse)
+                completionHandler(watsonResponse, RestError.noData)
                 return
             }
 
-            // parse json object
-            let result: RestResult<T>
+            // parse response body as a JSONobject
             do {
-                let object = try JSON.decoder.decode(T.self, from: data)
-                result = .success(object)
+                watsonResponse.result = try JSON.decoder.decode(T.self, from: data)
+                completionHandler(watsonResponse, nil)
             } catch {
-                result = .failure(error)
+                completionHandler(nil, error)
             }
-
-            // execute completion handler
-            let dataResponse = RestResponse(response: response, data: data, result: result)
-            completionHandler(dataResponse)
-        }
-    }
-
-    /**
-     Execute this request and process the response body as a string.
-
-     - completionHandler: The completion handler to call when the request is complete.
-     */
-    public func responseString(
-        completionHandler: @escaping (RestResponse<String>) -> Void)
-    {
-        // execute the request
-        response { data, response, error in
-
-            // ensure there is no underlying error
-            guard error == nil else {
-                // swiftlint:disable:next force_unwrapping
-                let result = RestResult<String>.failure(error!)
-                let dataResponse = RestResponse(response: response, data: data, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
-            // ensure there is data to parse
-            guard let data = data else {
-                let result = RestResult<String>.failure(RestError.noData)
-                let dataResponse = RestResponse(response: response, data: nil, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
-            // parse data as a string
-            guard let string = String(data: data, encoding: .utf8) else {
-                let result = RestResult<String>.failure(RestError.serializationError)
-                let dataResponse = RestResponse(response: response, data: nil, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
-            // execute completion handler
-            let result = RestResult.success(string)
-            let dataResponse = RestResponse(response: response, data: data, result: result)
-            completionHandler(dataResponse)
         }
     }
 
@@ -293,24 +252,21 @@ extension RestRequest {
      - completionHandler: The completion handler to call when the request is complete.
      */
     public func responseVoid(
-        completionHandler: @escaping (RestResponse<Void>) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
     {
         // execute the request
-        response { data, response, error in
+        execute { _, response, error in
 
             // ensure there is no underlying error
-            guard error == nil else {
-                // swiftlint:disable:next force_unwrapping
-                let result = RestResult<Void>.failure(error!)
-                let dataResponse = RestResponse(response: response, data: data, result: result)
-                completionHandler(dataResponse)
+            guard let response = response, error == nil else {
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
 
+            let watsonResponse = WatsonResponse<Void>(response: response)
+
             // execute completion handler
-            let result = RestResult<Void>.success(())
-            let dataResponse = RestResponse(response: response, data: data, result: result)
-            completionHandler(dataResponse)
+            completionHandler(watsonResponse, nil)
         }
     }
 
@@ -373,15 +329,4 @@ extension RestRequest {
             task.resume()
         }
     }
-}
-
-public struct RestResponse<T> {
-    public let response: HTTPURLResponse?
-    public let data: Data?
-    public let result: RestResult<T>
-}
-
-public enum RestResult<T> {
-    case success(T)
-    case failure(Error)
 }

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -230,7 +230,7 @@ extension RestRequest {
                 let values = "response JSON: value not found for \(keyPath): " + context.debugDescription
                 completionHandler(nil, RestError.serialization(values: values))
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON " + error.localizedDescription))
+                completionHandler(nil, RestError.serialization(values: "response JSON: " + error.localizedDescription))
             }
         }
     }

--- a/Sources/RestKit/RestResponse.swift
+++ b/Sources/RestKit/RestResponse.swift
@@ -16,13 +16,13 @@
 
 import Foundation
 
-// MARK: - WatsonResponse
+// MARK: - RestResponse
 
 /**
  Common response type for all service methods that encapsulates the response status,
  response headers if any, and the result of the service call of the parameterized type T.
  */
-public struct WatsonResponse<T> {
+public struct RestResponse<T> {
 
     /**
      The HTTP status code.

--- a/Sources/RestKit/WatsonResponse.swift
+++ b/Sources/RestKit/WatsonResponse.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+// MARK: - WatsonResponse
+
+/**
+ Common response type for all service methods that encapsulates the response status,
+ response headers if any, and the result of the service call of the parameterized type T.
+ */
+public struct WatsonResponse<T> {
+
+    /**
+     The HTTP status code.
+     */
+    public var statusCode: Int
+
+    /**
+     A dictionary containing the HTTP response headers.
+     */
+    public var headers: [String: String]
+
+    /**
+     The result.
+     */
+    public var result: T?
+
+    public init(statusCode: Int, headers: [String: String] = [:]) {
+        self.statusCode = statusCode
+        self.headers = headers
+    }
+
+    internal init(response: HTTPURLResponse) {
+        var headers: [String: String] = [:]
+        for (key, value) in response.allHeaderFields {
+            if let key = key as? String,
+                let value = value as? String {
+                headers[key] = value
+            }
+        }
+        self.init(statusCode: response.statusCode, headers: headers)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,4 +6,5 @@ XCTMain([
     testCase(AuthenticationTests.allTests),
     testCase(CodableExtensionsTests.allTests),
     testCase(JSONTests.allTests),
+    testCase(RestErrorTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,5 +7,6 @@ XCTMain([
     testCase(CodableExtensionsTests.allTests),
     testCase(JSONTests.allTests),
     testCase(RestErrorTests.allTests),
+    testCase(ResponseTests.allTests),
     testCase(MultiPartFormDataTests.allTests),
 ])

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -31,7 +31,7 @@ class AuthenticationTests: XCTestCase {
         ("testIAMAuthentication", testIAMAuthentication),
     ]
 
-    internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
         return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -33,7 +33,7 @@ class AuthenticationTests: XCTestCase {
 
     internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.failure(response.statusCode, genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage)
     }
 
     var request = RestRequest(

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -33,7 +33,7 @@ class AuthenticationTests: XCTestCase {
 
     internal static func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
         let genericMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
-        return RestError.http(statusCode: response.statusCode, message: genericMessage)
+        return RestError.http(statusCode: response.statusCode, message: genericMessage, metadata: nil)
     }
 
     var request = RestRequest(

--- a/Tests/RestKitTests/MockURLProtocol.swift
+++ b/Tests/RestKitTests/MockURLProtocol.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+/**
+ * MockURLProtocol from WWDC 2018 Session 417 Testing Tips & Tricks
+ */
+class MockURLProtocol: URLProtocol {
+
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            XCTFail("Received unexpected request with no handler set")
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // Don't delete this method!  Without it, your tests will crash
+        // in com.apple.CFNetwork.CustomProtocols
+    }
+
+}

--- a/Tests/RestKitTests/MultiPartFormDataTests.swift
+++ b/Tests/RestKitTests/MultiPartFormDataTests.swift
@@ -25,19 +25,9 @@ class MultiPartFormDataTests: XCTestCase {
         ("testSimpleFormData", testSimpleFormData),
         ("testFormData", testFormData),
         ("testFormDataFromURL", testFormDataFromURL),
-        ("testFormDataWithInvalidURL", testFormDataWithInvalidURL)
+        ("testFormDataWithInvalidURL", testFormDataWithInvalidURL),
     ]
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func loadResource(name: String, ext: String) -> URL {
         #if os(Linux)
         return URL(fileURLWithPath: "Tests/RestKitTests/Resources/" + name + "." + ext)

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -1,0 +1,184 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import RestKit
+
+class ResponseTests: XCTestCase {
+
+    static var allTests = [
+        ("testDataCorruptedError", testDataCorruptedError),
+        ]
+
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+        let statusCode = response.statusCode
+        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
+    }
+
+    // MARK: Decoding errors
+
+    class Document : Codable {
+        let id: String
+        let name: String?
+        let status: DocumentStatus?
+    }
+
+    class DocumentStatus : Codable {
+        let created: Date?
+        let updated: Date?
+    }
+
+    func testDataCorruptedError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": \"12345\", \"status\": { \"created\": \"\" } }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_data_corrputed_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: dataCorrupted at status.created: Date string does not match format expected by formatter."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testKeyNotFoundError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"name\": \"A document with no id\"}".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_key_not_found_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: key not found for id"
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testTypeMismatchError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": \"12345\", \"status\": { \"updated\": 3.14159626 } }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_type_mismatch_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: type mismatch for status.updated: Expected to decode String but found a number instead."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+    func testValueNotFoundError() {
+        // Create mock session
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: configuration)
+        // Configure mock
+        MockURLProtocol.requestHandler = { request in
+            // Setup mock result
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = "{ \"id\": null, \"name\": \"document with null id\" }".data(using: .utf8)
+            return (response, data)
+        }
+
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "http://restkit.com/response_tests/test_value_not_found_error",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard let error = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            let expected = "Failed to serialize response JSON: value not found for id: Expected String value but found null instead."
+            XCTAssertEqual(expected, error.localizedDescription)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
+}

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -19,33 +19,23 @@ import RestKit
 
 class ResponseTests: XCTestCase {
 
+    // Mock URLSession
+    var configuration: URLSessionConfiguration!
+    var mockSession: URLSession!
+
+    override func setUp() {
+        configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: configuration)
+    }
+
     static var allTests = [
         ("testDataCorruptedError", testDataCorruptedError),
-        ]
+    ]
 
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
-        let statusCode = response.statusCode
-        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
-    }
-
-    // MARK: Decoding errors
-
-    class Document : Codable {
-        let id: String
-        let name: String?
-        let status: DocumentStatus?
-    }
-
-    class DocumentStatus : Codable {
-        let created: Date?
-        let updated: Date?
-    }
+    // MARK: - Tests
 
     func testDataCorruptedError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -77,10 +67,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testKeyNotFoundError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -112,10 +98,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testTypeMismatchError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -147,10 +129,6 @@ class ResponseTests: XCTestCase {
     }
 
     func testValueNotFoundError() {
-        // Create mock session
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        let mockSession = URLSession(configuration: configuration)
         // Configure mock
         MockURLProtocol.requestHandler = { request in
             // Setup mock result
@@ -181,4 +159,22 @@ class ResponseTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+
+    // MARK: - Helpers
+
+    class Document : Codable {
+        let id: String
+        let name: String?
+        let status: DocumentStatus?
+    }
+
+    class DocumentStatus : Codable {
+        let created: Date?
+        let updated: Date?
+    }
+
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+        let statusCode = response.statusCode
+        return RestError.http(statusCode: statusCode, message: "error message", metadata: nil)
+    }
 }

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -24,13 +24,16 @@ class ResponseTests: XCTestCase {
     var mockSession: URLSession!
 
     override func setUp() {
-        configuration = URLSessionConfiguration.ephemeral
+        configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         mockSession = URLSession(configuration: configuration)
     }
 
     static var allTests = [
         ("testDataCorruptedError", testDataCorruptedError),
+        ("testKeyNotFoundError", testKeyNotFoundError),
+        ("testTypeMismatchError", testTypeMismatchError),
+        ("testValueNotFoundError", testValueNotFoundError),
     ]
 
     // MARK: - Tests

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -22,6 +22,7 @@ class RestErrorTests: XCTestCase {
     static var allTests = [
         ("testHTTPErrorStatusCode", testHTTPErrorStatusCode),
         ("testHTTPErrorMessage", testHTTPErrorMessage),
+        ("testHTTPErrorMetadata", testHTTPErrorMetadata),
     ]
 
     func testHTTPErrorStatusCode() {

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -27,24 +27,37 @@ class RestErrorTests: XCTestCase {
 
     func testHTTPErrorStatusCode() {
         let testStatusCode = 400
-        let httpError = RestError.http(statusCode: testStatusCode, message: "Success")
+        let httpError = RestError.http(statusCode: testStatusCode, message: "Success", metadata: nil)
 
-        XCTAssertEqual(httpError.statusCode, testStatusCode)
+        guard case RestError.http(let statusCode, _, _) = httpError else {
+            XCTFail("Expected RestError.http")
+        }
+        XCTAssertEqual(statusCode, testStatusCode)
     }
 
     func testHTTPErrorMessage() {
         let testMessage = "Something went wrong"
-        let httpError = RestError.http(statusCode: 500, message: testMessage)
+        let httpError = RestError.http(statusCode: 500, message: testMessage, metadata: nil)
 
+        guard case RestError.http(_, let message, _) = httpError else {
+            XCTFail("Expected RestError.http")
+        }
+        XCTAssertEqual(message, testMessage)
         XCTAssertEqual(httpError.errorDescription, testMessage)
     }
 
     func testHTTPErrorMetadata() {
         let testStatusCode = 500
-        let testMessage = "Something went wrong"
-        let httpError = RestError.http(statusCode: testStatusCode, message: testMessage)
+        let testMetadata: [String: JSON] = [
+            "key0": JSON.int(42),
+            "key1": JSON.boolean(true)
+        ]
+        let httpError = RestError.http(statusCode: testStatusCode, message: nil, metadata: testMetadata)
 
-        XCTAssertEqual(httpError.metadata!["status_code"]!, JSON.int(testStatusCode))
-        XCTAssertEqual(httpError.metadata!["message"]!, JSON.string(testMessage))
+        guard case RestError.http(_, _, let metadata) = httpError else {
+            XCTFail("Expected RestError.http")
+        }
+        XCTAssertEqual(metadata!["key0"]!, JSON.int(42))
+        XCTAssertEqual(metadata!["key1"]!, JSON.boolean(true))
     }
 }

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -1,0 +1,38 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+@testable import RestKit
+
+class RestErrorTests: XCTestCase {
+
+    static var allTests = [
+        ("testHTTPErrorStatusCode", testHTTPErrorStatusCode),
+        ("testHTTPErrorMessage", testHTTPErrorMessage),
+    ]
+
+    func testHTTPErrorStatusCode() {
+        let testStatusCode = 400
+        let httpError = RestError.http(statusCode: testStatusCode, message: "Success")
+        XCTAssertEqual(httpError.statusCode, testStatusCode)
+    }
+
+    func testHTTPErrorMessage() {
+        let testMessage = "Something went wrong"
+        let httpError = RestError.http(statusCode: 500, message: testMessage)
+        XCTAssertEqual(httpError.errorDescription, testMessage)
+    }
+}

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -48,16 +48,18 @@ class RestErrorTests: XCTestCase {
 
     func testHTTPErrorMetadata() {
         let testStatusCode = 500
-        let testMetadata: [String: JSON] = [
-            "key0": JSON.int(42),
-            "key1": JSON.boolean(true)
+        let testMetadata: [String: Any] = [
+            "key0": 42,
+            "key1": true,
+            "key2": "value"
         ]
         let httpError = RestError.http(statusCode: testStatusCode, message: nil, metadata: testMetadata)
 
         guard case RestError.http(_, _, let metadata) = httpError else {
             XCTFail("Expected RestError.http")
         }
-        XCTAssertEqual(metadata!["key0"]!, JSON.int(42))
-        XCTAssertEqual(metadata!["key1"]!, JSON.boolean(true))
+        XCTAssertEqual(metadata!["key0"] as? Int, 42)
+        XCTAssertEqual(metadata!["key1"] as? Bool, true)
+        XCTAssertEqual(metadata!["key2"] as? String, "value")
     }
 }

--- a/Tests/RestKitTests/RestErrorTests.swift
+++ b/Tests/RestKitTests/RestErrorTests.swift
@@ -27,12 +27,23 @@ class RestErrorTests: XCTestCase {
     func testHTTPErrorStatusCode() {
         let testStatusCode = 400
         let httpError = RestError.http(statusCode: testStatusCode, message: "Success")
+
         XCTAssertEqual(httpError.statusCode, testStatusCode)
     }
 
     func testHTTPErrorMessage() {
         let testMessage = "Something went wrong"
         let httpError = RestError.http(statusCode: 500, message: testMessage)
+
         XCTAssertEqual(httpError.errorDescription, testMessage)
+    }
+
+    func testHTTPErrorMetadata() {
+        let testStatusCode = 500
+        let testMessage = "Something went wrong"
+        let httpError = RestError.http(statusCode: testStatusCode, message: testMessage)
+
+        XCTAssertEqual(httpError.metadata!["status_code"]!, JSON.int(testStatusCode))
+        XCTAssertEqual(httpError.metadata!["message"]!, JSON.string(testMessage))
     }
 }


### PR DESCRIPTION
Most of this work was done to support the changes being made to the [Watson Swift SDK](https://github.com/watson-developer-cloud/swift-sdk) in preparation for its 1.0 release.

Major changes include:
1. Update supported versions of Xcode, iOS, and Swift
1. Improve the usefulness of `RestResponse`
1. Improve the usefulness of `RestError`. Replace usage of `Error` with `RestError`.
1. Remove `RestRequest.responseString()` (use `RestRequest.response()` instead)
1. Better error handling for `RestRequest.responseObject()`
1. Get rid of default value for `RestRequest.userAgent`