### PR TITLE
Capture IAM token to avoid reauthentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 xcuserdata/
 *.xcuserstate
 .build
+.DS_Store
+TestCredentials.swift

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		92BF69BB213F4BD800FE6325 /* RestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RestResponse.swift; path = RestKit/RestResponse.swift; sourceTree = "<group>"; };
 		CA17C8DD2190E33400677CA7 /* MockURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockURLProtocol.swift; path = RestKitTests/MockURLProtocol.swift; sourceTree = "<group>"; };
 		CA17C8DF2191063800677CA7 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResponseTests.swift; path = RestKitTests/ResponseTests.swift; sourceTree = "<group>"; };
+		CA1CD62421F5180D00CDCEA2 /* TestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCredentials.swift; sourceTree = "<group>"; };
 		CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiPartFormDataTests.swift; path = RestKitTests/MultiPartFormDataTests.swift; sourceTree = "<group>"; };
 		CA54276B215574380035F8B6 /* TestData.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestData.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -143,6 +144,7 @@
 			isa = PBXGroup;
 			children = (
 				92048D56212F49C8004FD822 /* Info.plist */,
+				CA1CD62421F5180D00CDCEA2 /* TestCredentials.swift */,
 			);
 			path = "Supporting Files";
 			sourceTree = "<group>";

--- a/Sources/RestKit/Authentication.swift
+++ b/Sources/RestKit/Authentication.swift
@@ -293,6 +293,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 completionHandler(nil, error)
                 return
             }
+            self.token = token
             completionHandler(token, nil)
         }
     }
@@ -315,6 +316,7 @@ public class IAMAuthentication: AuthenticationMethod {
                 completionHandler(nil, error)
                 return
             }
+            self.token = token
             completionHandler(token, nil)
         }
     }

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -187,6 +187,8 @@ class AuthenticationTests: XCTestCase {
         // 1. Set `IAMToken` access level to `internal`
         // 2. Set `IAMAuthentication.token` access level to `internal`
         // 3. Uncomment the code below
+        // 4. Add credentials to TestCredentials.swift in Supporting Files folder
+        // 5. Add TestCredentials.swift to the RestKitTests target
 
         // The `private` access level of the properties and functions in `IAMAuthentication` prohibit us from
         // modifying/calling them directly. As a result, this is hard to test properly (particularly token refresh).
@@ -195,7 +197,7 @@ class AuthenticationTests: XCTestCase {
 
         /**
 
-        let authMethod = IAMAuthentication(apiKey: WatsonCredentials.IAMAPIKey, url: WatsonCredentials.IAMURL)
+        let authMethod = IAMAuthentication(apiKey: TestCredentials.IAMAPIKey, url: TestCredentials.IAMURL)
         var authorizationHeader: String! // save initial authorization header (it should stay the same until refreshed)
         request.authMethod = authMethod
 
@@ -213,6 +215,8 @@ class AuthenticationTests: XCTestCase {
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 5)
+
+        sleep(1) // sleep for 1 second to make sure the unix time stamp increments
 
         // use the same iam token
         let expectation2 = self.expectation(description: "use the same iam token")


### PR DESCRIPTION
This PR fixes a hidden but significant bug in the IAM authentication logic that failed to retain the authentication token returned by a token request to IAM.  The impact of the bug was that _every_ request had to perform a token request prior to making the actual service request. With this fix, the token is stored an reused until it expires.