### PR TITLE
Add RestError.deserialization

### DIFF
--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -32,6 +32,9 @@ public enum RestError {
     /// Failed to serialize value(s) to data.
     case serialization(values: String)
 
+    /// Failed to deserialize value(s) to data.
+    case deserialization(values: String)
+
     /// Failed to replace special characters in the
     /// URL path with percent encoded characters.
     case urlEncoding(path: String)
@@ -59,6 +62,8 @@ extension RestError: LocalizedError {
             return "Failed to save the downloaded data. The specified file may already exist or the disk may be full."
         case .serialization(let values):
             return "Failed to serialize " + values
+        case .deserialization(let values):
+            return "Failed to deserialize " + values
         case .urlEncoding(let path):
             return "Failed to add percent encoding to \(path)"
         case .badURL:

--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -171,7 +171,7 @@ extension RestRequest {
             } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
-                    completionHandler(restResponse, RestError.serialization(values: "response string"))
+                    completionHandler(restResponse, RestError.deserialization(values: "response string"))
                     return
                 }
                 restResponse.result = string as? T
@@ -217,20 +217,20 @@ extension RestRequest {
             } catch DecodingError.dataCorrupted(let context) {
                 let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
                 let values = "response JSON: dataCorrupted at \(keyPath): " + context.debugDescription
-                completionHandler(nil, RestError.serialization(values: values))
+                completionHandler(nil, RestError.deserialization(values: values))
             } catch DecodingError.keyNotFound(let key, _) {
                 let values = "response JSON: key not found for \(key.stringValue)"
-                completionHandler(nil, RestError.serialization(values: values))
+                completionHandler(nil, RestError.deserialization(values: values))
             } catch DecodingError.typeMismatch(_, let context) {
                 let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
                 let values = "response JSON: type mismatch for \(keyPath): " + context.debugDescription
-                completionHandler(nil, RestError.serialization(values: values))
+                completionHandler(nil, RestError.deserialization(values: values))
             } catch DecodingError.valueNotFound(_, let context) {
                 let keyPath = context.codingPath.map{$0.stringValue}.joined(separator: ".")
                 let values = "response JSON: value not found for \(keyPath): " + context.debugDescription
-                completionHandler(nil, RestError.serialization(values: values))
+                completionHandler(nil, RestError.deserialization(values: values))
             } catch {
-                completionHandler(nil, RestError.serialization(values: "response JSON: " + error.localizedDescription))
+                completionHandler(nil, RestError.deserialization(values: "response JSON: " + error.localizedDescription))
             }
         }
     }

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -62,7 +62,7 @@ class ResponseTests: XCTestCase {
                 XCTFail("Expected error not received")
                 return
             }
-            let expected = "Failed to serialize response JSON: dataCorrupted at status.created: Date string does not match format expected by formatter."
+            let expected = "Failed to deserialize response JSON: dataCorrupted at status.created: Date string does not match format expected by formatter."
             XCTAssertEqual(expected, error.localizedDescription)
             expectation.fulfill()
         }
@@ -93,7 +93,7 @@ class ResponseTests: XCTestCase {
                 XCTFail("Expected error not received")
                 return
             }
-            let expected = "Failed to serialize response JSON: key not found for id"
+            let expected = "Failed to deserialize response JSON: key not found for id"
             XCTAssertEqual(expected, error.localizedDescription)
             expectation.fulfill()
         }
@@ -124,7 +124,7 @@ class ResponseTests: XCTestCase {
                 XCTFail("Expected error not received")
                 return
             }
-            let expected = "Failed to serialize response JSON: type mismatch for status.updated: Expected to decode String but found a number instead."
+            let expected = "Failed to deserialize response JSON: type mismatch for status.updated: Expected to decode String but found a number instead."
             XCTAssertEqual(expected, error.localizedDescription)
             expectation.fulfill()
         }
@@ -155,7 +155,7 @@ class ResponseTests: XCTestCase {
                 XCTFail("Expected error not received")
                 return
             }
-            let expected = "Failed to serialize response JSON: value not found for id: Expected String value but found null instead."
+            let expected = "Failed to deserialize response JSON: value not found for id: Expected String value but found null instead."
             XCTAssertEqual(expected, error.localizedDescription)
             expectation.fulfill()
         }


### PR DESCRIPTION
https://github.ibm.com/arf/planning-sdk-squad/issues/780

Added a new `RestError` case for `deserialization` to distinguish from `serialization`.

**Please DO NOT merge this into the develop branch until ready to release RestKit 3.0, as this is a breaking change.**