### PR TITLE
Return RestResponse with response headers for error responses

### DIFF
--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -151,13 +151,19 @@ extension RestRequest {
         // execute the request
         execute { data, response, error in
 
-            // ensure there is no underlying error
-            guard let response = response, error == nil else {
-                completionHandler(nil, error ?? RestError.noResponse)
+            // Check for response
+            guard let response = response else {
+                completionHandler(nil, RestError.noResponse)
                 return
             }
 
             var restResponse = RestResponse<T>(response: response)
+
+            // Check for service error
+            if let error = error {
+                completionHandler(restResponse, error)
+                return
+            }
 
             // ensure there is data to parse
             guard let data = data else {
@@ -196,13 +202,19 @@ extension RestRequest {
         // execute the request
         execute { data, response, error in
 
-            // ensure there is no underlying error
-            guard let response = response, error == nil else {
-                completionHandler(nil, error ?? RestError.noResponse)
+            // Check for response
+            guard let response = response else {
+                completionHandler(nil, RestError.noResponse)
                 return
             }
 
             var restResponse = RestResponse<T>(response: response)
+
+            // Check for service error
+            if let error = error {
+                completionHandler(restResponse, error)
+                return
+            }
 
             // ensure there is data to parse
             guard let data = data else {
@@ -246,13 +258,19 @@ extension RestRequest {
         // execute the request
         execute { _, response, error in
 
-            // ensure there is no underlying error
-            guard let response = response, error == nil else {
-                completionHandler(nil, error ?? RestError.noResponse)
+            // Check for response
+            guard let response = response else {
+                completionHandler(nil, RestError.noResponse)
                 return
             }
 
             let restResponse = RestResponse<Void>(response: response)
+
+            // Check for service error
+            if let error = error {
+                completionHandler(restResponse, error)
+                return
+            }
 
             // execute completion handler
             completionHandler(restResponse, nil)


### PR DESCRIPTION
### Summary

The current implementation of response processing in RestKit invokes the caller's completion handler with a nil RestResponse when the error is not nil.

This means that the caller is unable to inspect the response headers for any error condition. This is a problem because some error cases pass meaningful data in response headers, like transaction-ids for later debugging, or rate-limit information.

This PR modifies response processing so that a RestResponse is passed to the completion handler with response headers whenever a response is available.
