### PR TITLE
Propagate service error to caller if present

### DIFF
--- a/Sources/RestKit/RestRequest.swift
+++ b/Sources/RestKit/RestRequest.swift
@@ -153,7 +153,7 @@ extension RestRequest {
 
             // Check for response
             guard let response = response else {
-                completionHandler(nil, RestError.noResponse)
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
 
@@ -204,7 +204,7 @@ extension RestRequest {
 
             // Check for response
             guard let response = response else {
-                completionHandler(nil, RestError.noResponse)
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
 
@@ -260,7 +260,7 @@ extension RestRequest {
 
             // Check for response
             guard let response = response else {
-                completionHandler(nil, RestError.noResponse)
+                completionHandler(nil, error ?? RestError.noResponse)
                 return
             }
 

--- a/Tests/RestKitTests/ResponseTests.swift
+++ b/Tests/RestKitTests/ResponseTests.swift
@@ -194,6 +194,26 @@ class ResponseTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+    func testBadURL() {
+        let request = RestRequest(
+            session: mockSession,
+            authMethod: BasicAuthentication(username: "username", password: "password"),
+            errorResponseDecoder: errorResponseDecoder,
+            method: "POST",
+            url: "not valid",
+            headerParameters: [:]
+        )
+
+        let expectation = self.expectation(description: #function)
+        request.responseObject { (response: RestResponse<Document>?, error: RestError?) in
+            guard case .some(.badURL) = error else {
+                XCTFail("Expected error not received")
+                return
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
 
     // MARK: - Helpers
 


### PR DESCRIPTION
This PR fixes the code in #15, which inadvertently replaced an error from the service with `RestError.noResponse` if no response was returned. I've also added a test to verify the desired behavior. 