### PR TITLE
Add metadata associated value to RestError.other

### DIFF
--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -46,7 +46,7 @@ public enum RestError {
     case http(statusCode: Int?, message: String?, metadata: [String: Any]?)
 
     /// Error that does not fall under any other `RestError` category
-    case other(message: String?)
+    case other(message: String?, metadata: [String: Any]?)
 }
 
 
@@ -70,7 +70,7 @@ extension RestError: LocalizedError {
             return "Malformed URL"
         case .http(_, let message, _):
             return message
-        case .other(let message):
+        case .other(let message, _):
             return message
         }
     }


### PR DESCRIPTION
This PR adds a `metadata` associated value for RestError.other.

Previously, RestError.other only allowed a `message` (String) associated value, which isn't sufficient for capturing additional debugging information.