### PR TITLE
feat(baseservice): adds BaseService class and ServiceClient protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ TestCredentials.swift
 # ignore detect secrets files
 .pre-commit-config.yaml
 .secrets.baseline
+
+.idea/

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7E17AC0323143722005E538D /* ConfigBasedAuthenticatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E17AC0223143722005E538D /* ConfigBasedAuthenticatorFactory.swift */; };
+		7E434F8D232983FF00801042 /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E434F8C232983FF00801042 /* BaseService.swift */; };
 		7EB22AFC23181A4B000EB0E0 /* MultiPartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA542768215558740035F8B6 /* MultiPartFormDataTests.swift */; };
 		7EB22AFE23181B0E000EB0E0 /* ConfigBasedAuthenticatorFactoryTests-Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB22AFD23181B0E000EB0E0 /* ConfigBasedAuthenticatorFactoryTests-Linux.swift */; };
 		7EC735D22319AD3C00A73810 /* CredentialUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC735D12319AD3C00A73810 /* CredentialUtils.swift */; };
@@ -47,6 +48,7 @@
 
 /* Begin PBXFileReference section */
 		7E17AC0223143722005E538D /* ConfigBasedAuthenticatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConfigBasedAuthenticatorFactory.swift; path = Sources/RestKit/Authentication/ConfigBasedAuthenticatorFactory.swift; sourceTree = SOURCE_ROOT; };
+		7E434F8C232983FF00801042 /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BaseService.swift; path = RestKit/BaseService.swift; sourceTree = "<group>"; };
 		7EB22AFD23181B0E000EB0E0 /* ConfigBasedAuthenticatorFactoryTests-Linux.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ConfigBasedAuthenticatorFactoryTests-Linux.swift"; path = "RestKitTests/ConfigBasedAuthenticatorFactoryTests-Linux.swift"; sourceTree = "<group>"; };
 		7EC735D12319AD3C00A73810 /* CredentialUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CredentialUtils.swift; path = Sources/RestKit/CredentialUtils.swift; sourceTree = SOURCE_ROOT; };
 		7EC735D32319AD5300A73810 /* CredentialUtilsTests-Linux.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CredentialUtilsTests-Linux.swift"; path = "RestKitTests/CredentialUtilsTests-Linux.swift"; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				92048D85212F5BEE004FD822 /* RestError.swift */,
 				92048D81212F5BEE004FD822 /* RestRequest.swift */,
 				92BF69BB213F4BD800FE6325 /* RestResponse.swift */,
+				7E434F8C232983FF00801042 /* BaseService.swift */,
 				92048D60212F4B1F004FD822 /* Supporting Files */,
 			);
 			path = Sources;
@@ -328,6 +331,7 @@
 				92048D8E212F5BEE004FD822 /* JSON.swift in Sources */,
 				92BF69BC213F4BD800FE6325 /* RestResponse.swift in Sources */,
 				CAC2201A22B82AA200179A9E /* JWT.swift in Sources */,
+				7E434F8D232983FF00801042 /* BaseService.swift in Sources */,
 				CAC2201C22B82FD700179A9E /* InsecureConnection.swift in Sources */,
 				92048D8C212F5BEE004FD822 /* RestError.swift in Sources */,
 				92048D89212F5BEE004FD822 /* MultipartFormData.swift in Sources */,

--- a/Sources/RestKit/BaseService.swift
+++ b/Sources/RestKit/BaseService.swift
@@ -1,0 +1,40 @@
+/**
+ * (C) Copyright IBM Corp. 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol ServiceClient {
+    var serviceURL: String? { get set }
+    var authenticator: Authenticator { get }
+    var session: URLSession { get set }
+    var defaultHeaders: [String: String] { get set }
+}
+
+open class BaseService: ServiceClient {
+    public var serviceURL: String?
+    public var authenticator: Authenticator
+    public var defaultHeaders: [String: String]
+    public var session: URLSession
+
+    public init(authenticator: Authenticator) {
+        self.authenticator = authenticator
+        self.defaultHeaders = [String: String]()
+        self.session = URLSession(configuration: URLSessionConfiguration.default)
+    }
+}

--- a/Sources/RestKit/RestError.swift
+++ b/Sources/RestKit/RestError.swift
@@ -45,6 +45,10 @@ public enum RestError {
     /// The request failed because the URL was malformed.
     case badURL
 
+    /// The request could not be initiated because
+    /// no endpoint was provided
+    case noEndpoint
+
     /// Generic HTTP error with a status code and description.
     case http(statusCode: Int?, message: String?, metadata: [String: Any]?)
 
@@ -70,6 +74,8 @@ extension RestError: LocalizedError {
             return "Failed to add percent encoding to \(path)"
         case .badURL:
             return "Malformed URL"
+        case .noEndpoint:
+            return "No endpoint was provided for this request."
         case .http(_, let message, _):
             return message
         case .other(let message, _):


### PR DESCRIPTION
this adds some compiler time checks for the minimum properties we expect service clients to use

### Summary

This update adds two entities of note:

1. `BaseService` class - the super class we will use for all client service classes
2. `ClientService` protocol - the interface that all client service classes will conform to

This provides us with better compile-time enforcement of what properties we expect from each service class (Watson and beyond), as well as less property duplication for properties that are used across every service client currently.

For Watson specifically, this will require generator changes, we will remove a lot of class specific properties, and the main init method will look like this:

```swift
    public init(version: String, authenticator: Authenticator) {
        self.version = version
        RestRequest.userAgent = Shared.userAgent
        super.init(authenticator: authenticator)
    }
```

Where the `BaseService` constructor called would set:

```swift
    public init(authenticator: Authenticator) {
        self.authenticator = authenticator
        self.defaultHeaders = [String : String]()
        self.session = URLSession(configuration: URLSessionConfiguration.default)
    }
```

I will comment on the generator with specific changes to the templates, but I included that example just for context.